### PR TITLE
Jobspotter 64 get my job posts as a job post creator

### DIFF
--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/client/AddressServiceClient.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/client/AddressServiceClient.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient(name = "user-service")
+@FeignClient(name = "address-service")
 public interface AddressServiceClient {
 
     @GetMapping("/api/v1/users/addresses/{user-id}")

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/client/UserServiceClient.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/client/UserServiceClient.java
@@ -1,0 +1,21 @@
+package org.job_spotter.jobpost.client;
+
+import org.job_spotter.jobpost.dto.UserBasicInfoResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@FeignClient(name = "user-service")
+public interface UserServiceClient {
+
+    @GetMapping("/api/v1/users")
+    ResponseEntity<Map<UUID, UserBasicInfoResponse>> getUsersBasicInfoByIds(
+            @RequestParam List<UUID> userIds
+    );
+
+}

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java
@@ -12,6 +12,7 @@ import org.job_spotter.jobpost.authUtils.JWTUtils;
 import org.job_spotter.jobpost.dto.ErrorResponse;
 import org.job_spotter.jobpost.dto.JobPostApplyRequest;
 import org.job_spotter.jobpost.dto.JobPostPostRequest;
+import org.job_spotter.jobpost.dto.MyJobPostResponse;
 import org.job_spotter.jobpost.model.JobPost;
 import org.job_spotter.jobpost.service.JobPostService;
 import org.springframework.http.HttpStatus;
@@ -89,6 +90,17 @@ public class JobPostController {
         jobPostService.applyToJobPost(id, userId, jobPostApplyRequest);
 
         return ResponseEntity.noContent().build();
+    }
+
+
+    @GetMapping("/my-job-posts")
+    public ResponseEntity<List<MyJobPostResponse>> getMyJobPosts(
+            @RequestHeader("Authorization") String accessToken
+    ) throws Exception {
+        log.info("Getting my job posts");
+        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
+
+        return ResponseEntity.ok(jobPostService.getMyJobPosts(userId));
     }
 
     //Create job post with dummy data

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/ApplicantResponse.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/ApplicantResponse.java
@@ -1,6 +1,7 @@
 package org.job_spotter.jobpost.dto;
 
 import lombok.*;
+import org.job_spotter.jobpost.model.ApplicantStatus;
 
 import java.util.UUID;
 
@@ -20,6 +21,8 @@ public class ApplicantResponse {
     private String firstName;
 
     private String lastName;
+
+    private ApplicantStatus status;
 
 
 }

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/ApplicantResponse.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/ApplicantResponse.java
@@ -1,0 +1,25 @@
+package org.job_spotter.jobpost.dto;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class ApplicantResponse {
+
+    @EqualsAndHashCode.Include
+    private UUID userId;
+
+    private String username;
+
+    private String firstName;
+
+    private String lastName;
+
+
+}

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/MyJobPostResponse.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/MyJobPostResponse.java
@@ -1,0 +1,28 @@
+package org.job_spotter.jobpost.dto;
+
+import lombok.*;
+import org.job_spotter.jobpost.model.JobStatus;
+import org.job_spotter.jobpost.model.Tag;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyJobPostResponse {
+
+    private Long jobPostId;
+    private Set<Tag> tags;
+    private List<ApplicantResponse> applicants;
+    private String title;
+    private String description;
+    private String address;
+    private LocalDateTime datePosted;
+    private LocalDateTime lastUpdatedAt;
+    private int maxApplicants;
+    private JobStatus status;
+}

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/UserBasicInfoResponse.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/UserBasicInfoResponse.java
@@ -1,0 +1,24 @@
+package org.job_spotter.jobpost.dto;
+
+import lombok.*;
+
+import java.util.UUID;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserBasicInfoResponse {
+
+    private UUID userId;
+
+    private String username;
+
+    private String firstName;
+
+    private String lastName;
+
+
+}

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/deserializer/TagDeserializer.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/deserializer/TagDeserializer.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.job_spotter.jobpost.model.JobTagEnum;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -28,7 +27,9 @@ public class TagDeserializer extends JsonDeserializer<Set<JobTagEnum>> {
                 tags.add(JobTagEnum.valueOf(tagString)); // Add the tag if it's valid
             } catch (IllegalArgumentException e) {
                 // Handle invalid tag string here if needed
-                String allowedValues = Arrays.toString(JobTagEnum.values());
+
+                String allowedValues = JobTagEnum.getAllEnumNames();
+
                 throw new InvalidFormatException("Invalid value for Job Post Tags: '" + tagString + "'. Allowed values are: " + allowedValues, tagString, JobTagEnum.class);
             }
         }

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/model/JobTagEnum.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/model/JobTagEnum.java
@@ -1,5 +1,8 @@
 package org.job_spotter.jobpost.model;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public enum JobTagEnum {
 
     GENERAL_HELP(1L, "General Help"),
@@ -41,7 +44,14 @@ public enum JobTagEnum {
 
     @Override
     public String toString() {
-        return displayName;
+        return name();
+    }
+
+    // Method to get all enum names as string values in the format 'ENUM_NAME'
+    public static String getAllEnumNames() {
+        return Arrays.stream(JobTagEnum.values())
+                .map(JobTagEnum::name) // Get the enum constant name (e.g., GENERAL_HELP)
+                .collect(Collectors.joining(", ")); // Join the enum names with commas
     }
 
 }

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/repository/JobPostRepository.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/repository/JobPostRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface JobPostRepository extends JpaRepository<JobPost, Long> {
@@ -17,4 +18,5 @@ public interface JobPostRepository extends JpaRepository<JobPost, Long> {
 
     Optional<JobPost> findById(Long id);
 
+    List<JobPost> findAllByJobPosterId(UUID userId);
 }

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java
@@ -253,10 +253,10 @@ public class JobPostImpl implements JobPostService {
 //        TODO: Results may be large, consider adding pagination in the future
         List<JobPost> jobPosts = jobPostRepository.findAllByJobPosterId(userId);
 
-        // Extract applicant IDs from the job posts (assuming it's a Set or List of UUIDs)
+        // Extract applicant IDs from the job posts
         Set<UUID> applicantIds = new HashSet<>();
         for (JobPost jobPost : jobPosts) {
-            jobPost.getApplicants().forEach(applicant -> applicantIds.add(applicant.getUserId())); // Assuming applicants has userId
+            jobPost.getApplicants().forEach(applicant -> applicantIds.add(applicant.getUserId()));
         }
 
         // Fetch basic info for all applicants (map of UUID -> UserBasicInfoResponse)
@@ -277,6 +277,7 @@ public class JobPostImpl implements JobPostService {
                                         .username(userBasicInfo != null ? userBasicInfo.getUsername() : null)
                                         .firstName(userBasicInfo != null ? userBasicInfo.getFirstName() : null)
                                         .lastName(userBasicInfo != null ? userBasicInfo.getLastName() : null)
+                                        .status(applicant.getStatus())
                                         .build();
                             })
                             .collect(Collectors.toList());

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java
@@ -7,9 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.job_spotter.jobpost.authUtils.JWTUtils;
 import org.job_spotter.jobpost.client.AddressServiceClient;
-import org.job_spotter.jobpost.dto.AddressResponse;
-import org.job_spotter.jobpost.dto.JobPostApplyRequest;
-import org.job_spotter.jobpost.dto.JobPostPostRequest;
+import org.job_spotter.jobpost.client.UserServiceClient;
+import org.job_spotter.jobpost.dto.*;
 import org.job_spotter.jobpost.exception.*;
 import org.job_spotter.jobpost.model.*;
 import org.job_spotter.jobpost.repository.ApplicantRepository;
@@ -21,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +30,7 @@ public class JobPostImpl implements JobPostService {
     private final JobPostRepository jobPostRepository;
     private final TagRepository tagRepository;
     private final AddressServiceClient addressServiceClient;
+    private final UserServiceClient userServiceClient;
     private final ApplicantRepository applicantRepository;
 
 
@@ -180,7 +181,7 @@ public class JobPostImpl implements JobPostService {
 
             if (e.status() == HttpStatus.NOT_FOUND.value()) {
                 logAddressClientException(e);
-                throw new ServerException(getErrorMessageFromFeignException(e));
+                throw new ResourceNotFoundException(getErrorMessageFromFeignException(e));
 
             } else if (e.status() == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
                 logAddressClientException(e);
@@ -245,6 +246,58 @@ public class JobPostImpl implements JobPostService {
         log.info("User applied to job post successfully");
 
         return HttpStatus.CREATED;
+    }
+
+    @Override
+    public List<MyJobPostResponse> getMyJobPosts(UUID userId) {
+//        TODO: Results may be large, consider adding pagination in the future
+        List<JobPost> jobPosts = jobPostRepository.findAllByJobPosterId(userId);
+
+        // Extract applicant IDs from the job posts (assuming it's a Set or List of UUIDs)
+        Set<UUID> applicantIds = new HashSet<>();
+        for (JobPost jobPost : jobPosts) {
+            jobPost.getApplicants().forEach(applicant -> applicantIds.add(applicant.getUserId())); // Assuming applicants has userId
+        }
+
+        // Fetch basic info for all applicants (map of UUID -> UserBasicInfoResponse)
+        ResponseEntity <Map<UUID, UserBasicInfoResponse>> applicantsBasicInfoResponse = userServiceClient.getUsersBasicInfoByIds(new ArrayList<>(applicantIds));
+
+        Map<UUID, UserBasicInfoResponse> applicantsBasicInfo = applicantsBasicInfoResponse.getBody();
+
+        // Now, map the job posts to MyJobPostResponse
+        List<MyJobPostResponse> myJobPostResponses = jobPosts.stream()
+                .map(jobPost -> {
+                    // Create a list of ApplicantResponse for each job post
+                    List<ApplicantResponse> applicantResponses = jobPost.getApplicants().stream()
+                            .map(applicant -> {
+                                // Use the map to fetch the applicant's basic info
+                                UserBasicInfoResponse userBasicInfo = applicantsBasicInfo.get(applicant.getUserId());
+                                return ApplicantResponse.builder()
+                                        .userId(applicant.getUserId())
+                                        .username(userBasicInfo != null ? userBasicInfo.getUsername() : null)
+                                        .firstName(userBasicInfo != null ? userBasicInfo.getFirstName() : null)
+                                        .lastName(userBasicInfo != null ? userBasicInfo.getLastName() : null)
+                                        .build();
+                            })
+                            .collect(Collectors.toList());
+
+                    // Create MyJobPostResponse with the applicants' info included
+                    return MyJobPostResponse.builder()
+                            .jobPostId(jobPost.getJobPostId())
+                            .tags(jobPost.getTags())
+                            .applicants(applicantResponses)  // This now contains the basic info for each applicant
+                            .title(jobPost.getTitle())
+                            .description(jobPost.getDescription())
+                            .address(jobPost.getAddress())
+                            .datePosted(jobPost.getDatePosted())
+                            .lastUpdatedAt(jobPost.getLastUpdatedAt())
+                            .maxApplicants(jobPost.getMaxApplicants())
+                            .status(jobPost.getStatus())
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return myJobPostResponses;  // Returning the list of job posts with populated applicants' info
     }
 
     private static void logAddressClientException(FeignClientException e) {

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/JobPostService.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/JobPostService.java
@@ -2,6 +2,7 @@ package org.job_spotter.jobpost.service;
 
 import org.job_spotter.jobpost.dto.JobPostApplyRequest;
 import org.job_spotter.jobpost.dto.JobPostPostRequest;
+import org.job_spotter.jobpost.dto.MyJobPostResponse;
 import org.job_spotter.jobpost.model.JobPost;
 import org.springframework.http.HttpStatus;
 
@@ -19,4 +20,6 @@ public interface JobPostService {
     Long createJobPost(JobPostPostRequest jobPostPostRequest, String accessToken);
 
     HttpStatus applyToJobPost(Long id, UUID userId, JobPostApplyRequest jobPostApplyRequest);
+
+    List<MyJobPostResponse> getMyJobPosts(UUID userId);
 }

--- a/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/controller/UserController.java
+++ b/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/controller/UserController.java
@@ -22,6 +22,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -162,6 +164,15 @@ public class UserController {
     ) {
         log.info("Getting user details");
         return userService.getUserById(accessToken);
+    }
+
+
+    @GetMapping()
+    public ResponseEntity<Map<UUID, UserBasicInfoResponse>> getUsersBasicInfo(
+            @RequestParam List<UUID> userIds
+            ) {
+        log.info("Getting user details");
+        return userService.getAllByIds(userIds);
     }
 
 

--- a/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/dto/UserBasicInfoResponse.java
+++ b/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/dto/UserBasicInfoResponse.java
@@ -1,0 +1,24 @@
+package org.jobspotter.user.dto;
+
+import lombok.*;
+
+import java.util.UUID;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserBasicInfoResponse {
+
+    private UUID userId;
+
+    private String username;
+
+    private String firstName;
+
+    private String lastName;
+
+
+}

--- a/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/repository/UserRepository.java
+++ b/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/repository/UserRepository.java
@@ -1,10 +1,10 @@
 package org.jobspotter.user.repository;
 
-import jakarta.validation.constraints.Email;
 import org.jobspotter.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 
@@ -19,4 +19,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     boolean existsByUsernameAndEmail(String username, String email);
 
     User findByUserId(UUID userIdFromToken);
+
+    List<User> findAllByUserIdIn(List<UUID> userIds);
 }

--- a/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/UserService.java
+++ b/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/UserService.java
@@ -1,9 +1,10 @@
 package org.jobspotter.user.service;
 import org.jobspotter.user.dto.*;
-import org.jobspotter.user.model.User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface UserService {
@@ -16,4 +17,6 @@ public interface UserService {
     ResponseEntity<UserResponse> getUserById(String accessToken);
 
     ResponseEntity<UserResponse> updateUser(UUID userId, UserPatchRequest userPatchRequest);
+
+    ResponseEntity<Map<UUID, UserBasicInfoResponse>> getAllByIds(List<UUID> userIds);
 }

--- a/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/implementation/UserServiceImpl.java
+++ b/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/implementation/UserServiceImpl.java
@@ -3,7 +3,9 @@ package org.jobspotter.user.service.implementation;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -142,6 +144,28 @@ public class UserServiceImpl implements UserService {
                 .userType(user.getUserType())
                 .build()
         );
+    }
+
+    @Override
+    public ResponseEntity<Map<UUID, UserBasicInfoResponse>> getAllByIds(List<UUID> userIds) {
+
+        List<User> users = userRepository.findAllByUserIdIn(userIds);
+
+        // Use stream to collect the data into a map
+        Map<UUID, UserBasicInfoResponse> usersResponseMap = users.stream()
+                .collect(Collectors.toMap(
+                        User::getUserId,
+                        user -> UserBasicInfoResponse.builder()
+                                .userId(user.getUserId())
+                                .username(user.getUsername())
+                                .firstName(user.getFirstName())
+                                .lastName(user.getLastName())
+                                .build()
+                ));
+
+        // Return the map wrapped in a ResponseEntity
+        return ResponseEntity.ok(usersResponseMap);
+
     }
 
 


### PR DESCRIPTION
### New Features and Enhancements:
- **Service Clients:** 
  - Added `UserServiceClient` to fetch user basic info.
  - Updated `AddressServiceClient` for correct service name.
- **Controllers:** 
  - New endpoint in `JobPostController` to retrieve user's created job posts.
- **DTOs:** 
  - Introduced `ApplicantResponse`, `MyJobPostResponse`, and `UserBasicInfoResponse` DTOs.
- **Service Implementations:**
  - Implemented `getMyJobPosts` in `JobPostImpl` to fetch job posts and populate applicant info via `UserServiceClient`.

### Codebase Improvements:
- **Enums:** 
  - Added method in `JobTagEnum` to get all enum names as a comma-separated string for improved error handling in `TagDeserializer`.
- **Repositories:**
  - Updated `JobPostRepository` to find posts by user ID.
  - Updated `UserRepository` to find users by a list of user IDs.
- **Error Handling:** 
  - Enhanced exception handling in `JobPostImpl` to throw `ResourceNotFoundException` for address client errors.
