### PR TITLE
Jobspotter 68 get job posts i have applied to worked on

### DIFF
--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java
@@ -13,6 +13,7 @@ import org.job_spotter.jobpost.authUtils.JWTUtils;
 import org.job_spotter.jobpost.dto.*;
 import org.job_spotter.jobpost.model.JobPost;
 import org.job_spotter.jobpost.service.JobPostService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -146,6 +147,27 @@ public class JobPostController {
         UUID userId = JWTUtils.getUserIdFromToken(accessToken);
 
         return ResponseEntity.ok(jobPostService.getMyJobPosts(userId));
+    }
+
+
+
+    @GetMapping("/history")
+    public ResponseEntity<Page<JobPostsUserWorkedOnResponse>> getJobsUserWorkedOn(
+
+            @RequestHeader("Authorization") String accessToken,
+
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "sortBy", defaultValue = "datePosted") String sortBy,
+            @RequestParam(value = "sortDirection", defaultValue = "asc") String sortDirection,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "title", required = false) String title
+
+    ) throws Exception {
+        log.info("Getting my worked jobs");
+        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
+
+        return ResponseEntity.ok(jobPostService.getJobsUserWorkedOn(userId, page, size, sortBy, sortDirection, status, title));
     }
 
 

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/JobPostsUserWorkedOnResponse.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/JobPostsUserWorkedOnResponse.java
@@ -1,0 +1,29 @@
+package org.job_spotter.jobpost.dto;
+
+import lombok.*;
+import org.job_spotter.jobpost.model.JobStatus;
+import org.job_spotter.jobpost.model.Tag;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class JobPostsUserWorkedOnResponse {
+
+    private Long jobPostId;
+    private Set<Tag> tags;
+    private int applicantsCount;
+    private String title;
+    private String description;
+    private String address;
+    private LocalDateTime datePosted;
+    private LocalDateTime lastUpdatedAt;
+    private int maxApplicants;
+    private JobStatus status;
+
+}

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/repository/JobPostSpecificationRepository.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/repository/JobPostSpecificationRepository.java
@@ -1,0 +1,10 @@
+package org.job_spotter.jobpost.repository;
+
+import org.job_spotter.jobpost.model.JobPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JobPostSpecificationRepository extends JpaRepository<JobPost, Long>, JpaSpecificationExecutor<JobPost> {
+}

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/repository/specification/JobPostSpecification.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/repository/specification/JobPostSpecification.java
@@ -1,0 +1,39 @@
+package org.job_spotter.jobpost.repository.specification;
+
+import org.job_spotter.jobpost.model.JobPost;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+public class JobPostSpecification {
+
+    public static Specification<JobPost> hasStatus(String status) {
+        return (root, query, criteriaBuilder) ->
+                StringUtils.hasText(status) ?
+                        criteriaBuilder.equal(root.get("status"), status) :
+                        criteriaBuilder.conjunction(); // Match all if status is null
+    }
+
+    public static Specification<JobPost> hasTitle(String title) {
+        return (root, query, criteriaBuilder) ->
+                StringUtils.hasText(title) ?
+                        criteriaBuilder.like(criteriaBuilder.lower(root.get("title")), "%" + title.toLowerCase() + "%") :
+                        criteriaBuilder.conjunction(); // Match all if title is null
+    }
+
+    public static Specification<JobPost> wasWorkedOnBy(UUID userId) {
+        return (root, query, criteriaBuilder) -> {
+            // Join with applications table (assuming the relationship exists)
+            return criteriaBuilder.equal(root.join("applicants").get("userId"), userId);
+        };
+    }
+
+    // Combine multiple filters into a single specification
+    public static Specification<JobPost> filterByParams(String status, String title, UUID userId) {
+        return Specification.where(wasWorkedOnBy(userId)) // Always filter by userId
+                .and(hasStatus(status))
+                .and(hasTitle(title));
+    }
+
+}

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java
@@ -257,6 +257,7 @@ public class JobPostImpl implements JobPostService {
 
     @Override
     public List<MyJobPostResponse> getMyJobPosts(UUID userId) {
+//        TODO: implement pagination and filtering
 //        TODO: Results may be large, consider adding pagination in the future
         List<JobPost> jobPosts = jobPostRepository.findAllByJobPosterId(userId);
 

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java
@@ -13,8 +13,15 @@ import org.job_spotter.jobpost.exception.*;
 import org.job_spotter.jobpost.model.*;
 import org.job_spotter.jobpost.repository.ApplicantRepository;
 import org.job_spotter.jobpost.repository.JobPostRepository;
+import org.job_spotter.jobpost.repository.JobPostSpecificationRepository;
 import org.job_spotter.jobpost.repository.TagRepository;
+import org.job_spotter.jobpost.repository.specification.JobPostSpecification;
 import org.job_spotter.jobpost.service.JobPostService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -31,6 +38,7 @@ public class JobPostImpl implements JobPostService {
     private final TagRepository tagRepository;
     private final UserServiceClient userServiceClient;
     private final ApplicantRepository applicantRepository;
+    private final JobPostSpecificationRepository jobPostSpecificationRepository;
 
 
     @Override
@@ -498,8 +506,50 @@ public class JobPostImpl implements JobPostService {
         return HttpStatus.NO_CONTENT;
     }
 
+    @Override
+    public Page<JobPostsUserWorkedOnResponse> getJobsUserWorkedOn(UUID userId, int page, int size, String sortBy, String sortDirection, String status, String title) {
+
+        // Define allowed sorting fields
+        Set<String> allowedSortFields = Set.of("datePosted", "lastUpdatedAt", "title", "status");
+
+        // Validate the sortBy parameter
+        if (!allowedSortFields.contains(sortBy)) {
+            throw new InvalidRequestException("Invalid sortBy parameter: " + sortBy);
+        }
+
+        // Create a Specification with dynamic filters
+        Specification<JobPost> spec = JobPostSpecification.filterByParams(status, title, userId);
+
+//
+        Sort.Direction direction = sortDirection.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+        // Paginate and sort
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+
+        // Fetch the filtered and paginated results
+        Page<JobPost> jobPosts = jobPostSpecificationRepository.findAll(spec, pageable);
+
+        return jobPosts.map(this::convertToResponse);
+
+    }
+
 
 //    ----------------------------------------- Helper methods -----------------------------------------
+
+    // Helper method to map JobPost to MyJobPostResponse
+    private JobPostsUserWorkedOnResponse convertToResponse(JobPost jobPost) {
+        return JobPostsUserWorkedOnResponse.builder()
+                .jobPostId(jobPost.getJobPostId())
+                .tags(jobPost.getTags())
+                .applicantsCount(jobPost.getApplicants().size()) // Assuming applicants is a collection
+                .title(jobPost.getTitle())
+                .description(jobPost.getDescription())
+                .address(jobPost.getAddress())
+                .datePosted(jobPost.getDatePosted())
+                .lastUpdatedAt(jobPost.getLastUpdatedAt())
+                .maxApplicants(jobPost.getMaxApplicants())
+                .status(jobPost.getStatus())
+                .build();
+    }
 
     private void checkIfUserIsJobPoster(UUID userId, JobPost jobPost) {
         if (!jobPost.getJobPosterId().equals(userId)) {

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/JobPostService.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/JobPostService.java
@@ -1,10 +1,8 @@
 package org.job_spotter.jobpost.service;
 
-import org.job_spotter.jobpost.dto.ApplicantActionRequest;
-import org.job_spotter.jobpost.dto.JobPostApplyRequest;
-import org.job_spotter.jobpost.dto.JobPostPostRequest;
-import org.job_spotter.jobpost.dto.MyJobPostResponse;
+import org.job_spotter.jobpost.dto.*;
 import org.job_spotter.jobpost.model.JobPost;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 
 import java.util.List;
@@ -31,4 +29,6 @@ public interface JobPostService {
     HttpStatus cancelJobPost(UUID userId, Long jobPostId);
 
     HttpStatus finishJobPost(UUID userId, Long id);
+
+    Page<JobPostsUserWorkedOnResponse> getJobsUserWorkedOn(UUID userId, int page, int size, String sortBy, String sortDirection, String status, String title);
 }


### PR DESCRIPTION
This pull request introduces a new feature to fetch job posts that a user has worked on, along with several supporting changes to the codebase. The main changes include adding a new endpoint, creating a new DTO, and implementing filtering and pagination in the service layer.

### New Feature: Fetch Job Posts User Worked On

* Added a new endpoint `getJobsUserWorkedOn` in `JobPostController` to fetch job posts a user has worked on, with support for pagination and filtering.
* Created a new DTO `JobPostsUserWorkedOnResponse` to represent the response structure for the new endpoint.

### Repository and Specification Enhancements

* Introduced `JobPostSpecificationRepository` to support JPA specifications for complex queries.
* Implemented `JobPostSpecification` to provide dynamic filtering capabilities based on job status, title, and user ID.

### Service Layer Updates

* Updated `JobPostService` interface to include the new method `getJobsUserWorkedOn`.
* Implemented the new method `getJobsUserWorkedOn` in `JobPostImpl` to handle the business logic for fetching and filtering job posts.