### PR TITLE
Jobspotter 94 get reviews for a job post back end

### DIFF
--- a/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/controller/ReviewController.java
+++ b/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/controller/ReviewController.java
@@ -156,6 +156,22 @@ public class ReviewController {
 
 
 
+    @Operation(
+            summary = "Get reviews left under a job post.",
+            description = "Get reviews of a job post based on the provided job post id. "
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved reviews of user",
+
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = PageImpl.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "Bad request",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @GetMapping("/job-post/{jobPostId}")
     public ResponseEntity<Page<ReviewResponse>> getReviewsOfJobPost(
             @PathVariable Long jobPostId,

--- a/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/controller/ReviewController.java
+++ b/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/controller/ReviewController.java
@@ -156,6 +156,19 @@ public class ReviewController {
 
 
 
+    @GetMapping("/job-post/{jobPostId}")
+    public ResponseEntity<Page<ReviewResponse>> getReviewsOfJobPost(
+            @PathVariable Long jobPostId,
+            @RequestParam(required = false, defaultValue = "0") int pageNum,
+            @RequestParam(required = false, defaultValue = "10") int pageSize
+    ) {
+        Page<ReviewResponse> result = reviewService.getReviewsByJobPostId(jobPostId, pageNum, pageSize);
+
+        return ResponseEntity.ok(result);
+    }
+
+
+
 
 
 

--- a/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/repository/ReviewRepository.java
+++ b/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/repository/ReviewRepository.java
@@ -1,7 +1,7 @@
 package org.jobspotter.review.repository;
 
+import org.jobspotter.review.dto.ReviewResponse;
 import org.jobspotter.review.model.Review;
-import org.jobspotter.review.model.ReviewerRole;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,5 +13,7 @@ import java.util.UUID;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     boolean existsByReviewerIdAndJobPostIdAndReviewedUserId(UUID userId, Long jobPostId, UUID reviewedUserId);
+
+    Page<ReviewResponse> findAllByJobPostId(Long jobPostId, PageRequest pageRequest);
 
 }

--- a/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/service/ReviewService.java
+++ b/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/service/ReviewService.java
@@ -20,4 +20,6 @@ public interface ReviewService {
     Long updateReview(UUID userId, ReviewEditRequest reviewRequest, Long reviewId);
 
     void deleteReview(UUID userId, Long reviewId);
+
+    Page<ReviewResponse> getReviewsByJobPostId(Long jobPostId, int pageNum, int pageSize);
 }

--- a/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/service/impl/ReviewServiceImpl.java
+++ b/jobspotter_backend/services/review/src/main/java/org/jobspotter/review/service/impl/ReviewServiceImpl.java
@@ -210,6 +210,25 @@ public class ReviewServiceImpl implements ReviewService {
         ratingRepository.save(userRatings);
     }
 
+    @Override
+    public Page<ReviewResponse> getReviewsByJobPostId(Long jobPostId, int pageNum, int pageSize) {
+
+        return reviewRepository.findAllByJobPostId(jobPostId, PageRequest.of(pageNum, pageSize))
+                .map(review -> ReviewResponse.builder()
+                        .reviewId(review.getReviewId())
+                        .reviewerId(review.getReviewerId())
+                        .reviewedUserId(review.getReviewedUserId())
+                        .jobPostId(review.getJobPostId())
+                        .reviewerRole(review.getReviewerRole())
+                        .rating(review.getRating())
+                        .comment(review.getComment())
+                        .dateCreated(review.getDateCreated())
+                        .dateUpdated(review.getDateUpdated())
+                        .build()
+                );
+
+    }
+
 
 
 


### PR DESCRIPTION
This pull request introduces a new feature to retrieve reviews for a specific job post. The changes span multiple files, including the controller, repository, and service layers. The most important changes are detailed below:

Enhancements to Review Retrieval:

* [`jobspotter_backend/services/review/src/main/java/org/jobspotter/review/controller/ReviewController.java`](diffhunk://#diff-b6e21892bfbb3bc8c2be8a5ee5e369600eeb9c479d74537543260892220cc989R159-R187): Added a new endpoint `getReviewsOfJobPost` with appropriate OpenAPI annotations to fetch reviews based on job post ID.

Repository Updates:

* [`jobspotter_backend/services/review/src/main/java/org/jobspotter/review/repository/ReviewRepository.java`](diffhunk://#diff-77e56c88fa5f9262773dd493b836550f5adc706efd220ddb3c1f5bfc8e4611e1R17-R18): Introduced a new method `findAllByJobPostId` to fetch reviews by job post ID.

Service Layer Modifications:

* [`jobspotter_backend/services/review/src/main/java/org/jobspotter/review/service/ReviewService.java`](diffhunk://#diff-ddedcf18ff958a6f3bec55226b7f69bee6eff2fcdc87fc7f2464c401f67fbdafR23-R24): Added a new method `getReviewsByJobPostId` to the `ReviewService` interface.
* [`jobspotter_backend/services/review/src/main/java/org/jobspotter/review/service/impl/ReviewServiceImpl.java`](diffhunk://#diff-eadeaea6b5fd3e167a6ff2bb27c914d62db95cc9846fae2d775de36e1e89963fR213-R231): Implemented the `getReviewsByJobPostId` method to map review entities to `ReviewResponse` DTOs.

Dependency Adjustments:

* [`jobspotter_backend/services/review/src/main/java/org/jobspotter/review/repository/ReviewRepository.java`](diffhunk://#diff-77e56c88fa5f9262773dd493b836550f5adc706efd220ddb3c1f5bfc8e4611e1R3-L4): Imported `ReviewResponse` DTO for use in the repository method.