### PR TITLE
feat: add endpoint to retrieve all job tag enums and update security …

### DIFF
--- a/jobspotter_backend/services/gateway/src/main/java/org/jobspotter/gateway/config/JwtRefreshFilter.java
+++ b/jobspotter_backend/services/gateway/src/main/java/org/jobspotter/gateway/config/JwtRefreshFilter.java
@@ -48,7 +48,9 @@ public class JwtRefreshFilter implements WebFilter {
         String path = request.getPath().value();
 
         if (path.contains("/login") || path.contains("/register") || path.contains("/webjars")
-                || path.contains("/swagger-ui") || path.contains("/swagger-ui.html") || path.contains("/search")
+                || path.contains("/swagger-ui") || path.contains("/swagger-ui.html")
+                || path.contains("/search")
+                || path.contains("/job-tags")
                 || path.contains("/v3/api-docs") || path.contains("/eureka") || path.contains("/actuator")) {
             return chain.filter(exchange);// Skip JWT validation here
         }

--- a/jobspotter_backend/services/gateway/src/main/java/org/jobspotter/gateway/config/SecurityConfig.java
+++ b/jobspotter_backend/services/gateway/src/main/java/org/jobspotter/gateway/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
 
                         .pathMatchers("/api/v1/users/auth/**").permitAll()
                         .pathMatchers("/eureka/**").permitAll()
+                        .pathMatchers(HttpMethod.GET,"/api/v1/job-posts/job-tags").permitAll()
                         .pathMatchers(HttpMethod.GET,"/api/v1/job-posts/search").permitAll()
                         .pathMatchers(HttpMethod.GET, "/api/v1/job-posts").permitAll()
                         .anyExchange().authenticated()

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.job_spotter.jobpost.authUtils.JWTUtils;
 import org.job_spotter.jobpost.dto.*;
+import org.job_spotter.jobpost.model.JobTagEnum;
 import org.job_spotter.jobpost.service.JobPostService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -19,8 +20,11 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/job-posts")
@@ -29,6 +33,24 @@ import java.util.UUID;
 public class JobPostController {
 
     private final JobPostService jobPostService;
+
+
+    //Get Job Post tag enums
+    @Operation(
+            summary = "Get all job tag enums",
+            description = "Returns a map of all job tag enum constants and their display names."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved job tag enums",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = Map.class))),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class)))
+    })
+    @GetMapping("/job-tags")
+    public ResponseEntity<Map<String, String>> getAllJobTags() {
+        return ResponseEntity.ok(JobTagEnum.getAllEnumValues());
+    }
+
 
     //Get Detailed job post by id
     @Operation(
@@ -52,7 +74,6 @@ public class JobPostController {
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-
     //TODO: Return response based on the perspective of the applicant
     @GetMapping("/{id}")
     public ResponseEntity<JobPostDetailedResponse> getJobPostById(

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/model/JobTagEnum.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/model/JobTagEnum.java
@@ -1,6 +1,7 @@
 package org.job_spotter.jobpost.model;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public enum JobTagEnum {
@@ -64,6 +65,12 @@ public enum JobTagEnum {
         return Arrays.stream(JobTagEnum.values())
                 .map(JobTagEnum::name) // Get the enum constant name (e.g., GENERAL_HELP)
                 .collect(Collectors.joining(", ")); // Join the enum names with commas
+    }
+
+    //Method to return the map of all enum values as Enum name and display name
+    public static Map<String, String> getAllEnumValues() {
+        return Arrays.stream(JobTagEnum.values())
+                .collect(Collectors.toMap(JobTagEnum::name, JobTagEnum::getDisplayName));
     }
 
 }


### PR DESCRIPTION
This pull request includes changes to add a new endpoint for retrieving job tag enums and updates to the security and JWT filter configurations to accommodate the new endpoint. Additionally, there are some minor code improvements and additions.

### New Feature:
* Added a new endpoint to the `JobPostController` to retrieve all job tag enums as a map of enum names and display names. (`jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java`)

### Security and JWT Filter Updates:
* Updated `SecurityConfig` to permit GET requests to the new `/api/v1/job-posts/job-tags` endpoint. (`jobspotter_backend/services/gateway/src/main/java/org/jobspotter/gateway/config/SecurityConfig.java`)
* Updated `JwtRefreshFilter` to skip JWT validation for the new `/job-tags` path. (`jobspotter_backend/services/gateway/src/main/java/org/jobspotter/gateway/config/JwtRefreshFilter.java`)

### Code Improvements:
* Added imports and utility methods to support the new job tag enums endpoint in `JobPostController`. (`jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java`) [[1]](diffhunk://#diff-9b17109abcdd991cadfb41f5a98599ffd64fc0efd130a8acd2ae70c3ccb49a7bR14) [[2]](diffhunk://#diff-9b17109abcdd991cadfb41f5a98599ffd64fc0efd130a8acd2ae70c3ccb49a7bR23-R27)
* Added a method to `JobTagEnum` to return a map of all enum values with their display names. (`jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/model/JobTagEnum.java`)