### PR TITLE
feat: Fixed Content Type error

### DIFF
--- a/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/implementation/S3BucketServiceImpl.java
+++ b/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/implementation/S3BucketServiceImpl.java
@@ -53,6 +53,7 @@ public class S3BucketServiceImpl implements S3BucketService {
         // Create a PutObjectRequest object
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
+                .contentType(file.getContentType())
                 .key(fileName)
                 .build();
 


### PR DESCRIPTION
This pull request includes an important change to the `uploadFile` method in the `S3BucketServiceImpl` class. The change ensures that the content type of the file being uploaded is correctly set in the `PutObjectRequest`.

* [`jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/implementation/S3BucketServiceImpl.java`](diffhunk://#diff-a931e0e6af922689af426a2b47c99e430cca5b43e6a358d7dc58f447826c3b68R56): Added a line to set the content type of the file in the `PutObjectRequest` object.