### PR TITLE
feat: implement Kafka consumer for notification processing with confi…

### DIFF
--- a/jobspotter_backend/services/config-server/src/main/resources/configurations/notification-service.properties
+++ b/jobspotter_backend/services/config-server/src/main/resources/configurations/notification-service.properties
@@ -4,3 +4,15 @@ server.port=8083
 #MongoDB
 spring.data.mongodb.uri=mongodb://admin:admin@localhost:27017/notification?authSource=admin
 spring.data.mongodb.authentication-database=admin
+
+#---------------------------Kafka--------------------------------
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=notification-group
+spring.kafka.consumer.auto-offset-reset=earliest
+
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.properties.spring.json.trusted.packages=*
+spring.kafka.consumer.properties.spring.json.value.default.type=org.jobspotter.notification.model.Notification
+spring.kafka.consumer.properties.spring.json.use.type.headers=false

--- a/jobspotter_backend/services/notification/pom.xml
+++ b/jobspotter_backend/services/notification/pom.xml
@@ -63,6 +63,15 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/Listener/NotificationKafkaConsumer.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/Listener/NotificationKafkaConsumer.java
@@ -1,0 +1,24 @@
+package org.jobspotter.notification.Listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jobspotter.notification.model.KafkaTopic;
+import org.jobspotter.notification.model.Notification;
+import org.jobspotter.notification.repository.NotificationRepository;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationKafkaConsumer {
+
+    private final NotificationRepository notificationRepository;
+
+    @KafkaListener(topicPattern = ".*", groupId = "${spring.kafka.consumer.group-id}")
+    public void consumeNotification(Notification notification) {
+        log.info("Received notification: {}", notification);
+        notificationRepository.save(notification).subscribe();
+    }
+}

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/config/KafkaConsumerConfig.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/config/KafkaConsumerConfig.java
@@ -1,0 +1,48 @@
+package org.jobspotter.notification.config;
+
+
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.jobspotter.notification.model.Notification;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.ssl.DefaultSslBundleRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+
+import java.util.HashMap;
+import java.util.Map;
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public Map<String, Object> consumerConfig() {
+        return kafkaProperties.buildConsumerProperties(new DefaultSslBundleRegistry());
+    }
+
+    @Bean
+    public ConsumerFactory<String, Notification> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfig());
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, Notification>> factory(
+            ConsumerFactory<String, Notification> consumerFactory
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, Notification> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+}

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/KafkaTopic.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/KafkaTopic.java
@@ -1,0 +1,11 @@
+package org.jobspotter.notification.model;
+
+public class KafkaTopic {
+    public static final String JOB_POST_CREATE = "job_post_created";
+    public static final String JOB_POST_UPDATE = "job_post_updated";
+    public static final String JOB_POST_CANCEL = "job_post_cancelled";
+    public static final String JOB_POST_START = "job_post_started";
+    public static final String JOB_POST_FINISH = "job_post_finished";
+    public static final String APPLICANT_APPLIED = "job_post_applicant_applied";
+    public static final String APPLICANT_CONFIRMED = "job_post_applicant_confirmed";
+}

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/Notification.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/Notification.java
@@ -18,7 +18,11 @@ public class Notification {
     @Id
     private String notificationID; // MongoDB uses String/ObjectId
 
-    private UUID userID;  // Storing user reference as String
+    private UUID destinationUserId;  // Storing user reference as String
+
+    private UUID sourceUserId; // Storing user reference as String
+
+    private String actionUrl;
 
     private Long jobPostID; // Storing jobPost reference as String (nullable)
 


### PR DESCRIPTION
This pull request introduces Kafka integration into the notification service of the JobSpotter backend. The changes include adding Kafka dependencies, configuring Kafka consumer settings, and implementing a Kafka consumer to handle incoming notifications. Additionally, some modifications were made to the `Notification` model to support the new functionality.

Kafka integration:

* Added Kafka configuration properties to `notification-service.properties` to set up Kafka consumer settings.
* Updated `pom.xml` to include `spring-kafka` and `spring-kafka-test` dependencies.
* Created `NotificationKafkaConsumer` class to listen to Kafka topics and process incoming notifications.
* Added `KafkaConsumerConfig` class to configure Kafka consumer factory and listener container.

Model updates:

* Updated `Notification` model to include `sourceUserId` and `actionUrl` fields.