### PR TITLE
feat: add notification streaming service

### DIFF
--- a/jobspotter_backend/services/job-post/pom.xml
+++ b/jobspotter_backend/services/job-post/pom.xml
@@ -81,7 +81,6 @@
 			<artifactId>jjwt-api</artifactId>
 			<version>0.12.6</version>
 		</dependency>
-
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-impl</artifactId>

--- a/jobspotter_backend/services/notification/pom.xml
+++ b/jobspotter_backend/services/notification/pom.xml
@@ -39,12 +39,34 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson for Gson -->
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -71,6 +93,16 @@
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/Listener/NotificationKafkaConsumer.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/Listener/NotificationKafkaConsumer.java
@@ -1,13 +1,14 @@
 package org.jobspotter.notification.Listener;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jobspotter.notification.model.KafkaTopic;
 import org.jobspotter.notification.model.Notification;
 import org.jobspotter.notification.repository.NotificationRepository;
+import org.jobspotter.notification.service.StreamService;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -15,10 +16,15 @@ import org.springframework.stereotype.Service;
 public class NotificationKafkaConsumer {
 
     private final NotificationRepository notificationRepository;
+    private final StreamService streamService;
 
     @KafkaListener(topicPattern = ".*", groupId = "${spring.kafka.consumer.group-id}")
     public void consumeNotification(Notification notification) {
         log.info("Received notification: {}", notification);
         notificationRepository.save(notification).subscribe();
+
+        UUID userId = notification.getSourceUserId();
+
+        streamService.sendNotification(userId, notification);
     }
 }

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/authUtils/JWTUtils.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/authUtils/JWTUtils.java
@@ -1,0 +1,88 @@
+package org.jobspotter.notification.authUtils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class JWTUtils {
+
+    private static String keycloakPublicKey;
+
+    @PostConstruct
+    public void init() {
+        keycloakPublicKey = System.getenv("KEYCLOAK_PUBLIC_KEY");
+    }
+
+
+    private static PublicKey getPublicKey() throws Exception {
+
+        // Decode the base64 encoded public key
+        byte[] decoded = Base64.getDecoder().decode(keycloakPublicKey);
+
+        // Convert the decoded key to a PublicKey object
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decoded);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return keyFactory.generatePublic(keySpec);
+    }
+
+    // Decode and verify JWT
+    public static Claims decodeAndVerifyJwt(String jwt) throws Exception {
+        PublicKey publicKey = getPublicKey();
+
+        Claims claims = Jwts
+                .parser()
+                .setSigningKey(publicKey)
+                .build()
+                .parseClaimsJws(jwt)
+                .getBody();
+
+        return claims;
+    }
+
+    // Extract resource roles for a specific client (e.g., "account", "realm-management") from JWT claims
+    public List<String> extractResourceRoles(Claims claims, String clientId) {
+        Map<String, Map<String, Object>> resourceAccess = (Map<String, Map<String, Object>>) claims.get("resource_access");
+        if (resourceAccess != null && resourceAccess.containsKey(clientId)) {
+            Map<String, Object> clientRoles = resourceAccess.get(clientId);
+            return (List<String>) clientRoles.get("roles");
+        }
+        return null;
+    }
+
+    public static UUID getUserIdFromToken(String token) throws Exception {
+        Claims claims = decodeAndVerifyJwt(formatToken(token));
+        return UUID.fromString(claims.getSubject());
+    }
+
+    // Check if the user has the 'admin' role in realm or resource access
+    public boolean hasAdminRole(String token) throws Exception {
+
+        Claims claims = decodeAndVerifyJwt(formatToken(token));
+        // Check 'realm_access' roles
+        List<String> realmManagementRoles = extractResourceRoles(claims, "realm-management");
+        log.info("User realm-management roles: {}", realmManagementRoles);
+        if (realmManagementRoles != null && realmManagementRoles.contains("realm-admin")) {
+            return true;
+        }
+
+        log.warn("User does not have admin role!");
+        throw new Exception("User does not have admin role!");
+    }
+
+
+    private static String formatToken(String token) {
+        return token.substring(7);
+    }
+}

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/controller/NotificationController.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/controller/NotificationController.java
@@ -2,18 +2,28 @@ package org.jobspotter.notification.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jobspotter.notification.authUtils.JWTUtils;
 import org.jobspotter.notification.model.Notification;
+import org.jobspotter.notification.model.NotificationType;
 import org.jobspotter.notification.service.NotificationService;
+import org.jobspotter.notification.service.StreamService;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationController {
+
+    private final StreamService streamService;
     private final NotificationService notificationService;
 
     @PostMapping
@@ -25,5 +35,33 @@ public class NotificationController {
     @GetMapping
     public Flux<Notification> getAllNotifications() {
         return notificationService.getAllNotifications();
+    }
+
+
+    @GetMapping("/stream")
+    public Flux<ServerSentEvent<Notification>> notificationStream(
+            @RequestHeader("Authorization") String accessToken
+    ) throws Exception {
+        // Extract the user ID from the access token.
+        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
+        return streamService.streamNotifications(userId);
+    }
+
+    @GetMapping("/simulate")
+    public ResponseEntity<String> simulateNotification(
+            @RequestHeader("Authorization") String accessToken
+    ) throws Exception {
+        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
+        Notification notification = Notification.builder()
+                .sourceUserId(userId)
+                .destinationUserId(userId)
+                .message("Senpai noticed you! (>‿o)")
+                .type(NotificationType.OTHER)
+                .build();
+
+        // Use the streaming service to send the notification to the given user
+        streamService.sendNotification(userId, notification);
+
+        return ResponseEntity.ok("Simulated notification sent");
     }
 }

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/Notification.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/Notification.java
@@ -1,15 +1,16 @@
 package org.jobspotter.notification.model;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@Document(collection = "notification") // MongoDB Collection
+@Document(collection = "notification")// MongoDB Collection
+@Getter
+@Builder
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/Implementation/StreamImpl.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/Implementation/StreamImpl.java
@@ -1,0 +1,61 @@
+package org.jobspotter.notification.service.Implementation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jobspotter.notification.model.Notification;
+import org.jobspotter.notification.model.NotificationType;
+import org.jobspotter.notification.service.StreamService;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+public class StreamImpl implements StreamService {
+
+    // Map to keep track of FluxSinks for each user.
+    private final Map<UUID, FluxSink<Notification>> sinks = new ConcurrentHashMap<>();
+
+    /**
+     * Stream notifications to the user using the userId
+     *
+     * @param userId The userId of the user
+     * @return A Flux of ServerSentEvents containing the notifications
+     */
+    // Map to keep track of SseEmitters for each user.
+    @Override
+    public Flux<ServerSentEvent<Notification>> streamNotifications(UUID userId) {
+        return Flux.<Notification>create(emitter -> {
+                    // Save the sink so we can push notifications later.
+                    sinks.put(userId, emitter);
+                    // Remove the sink if the connection is closed.
+                    emitter.onDispose(() -> sinks.remove(userId));
+                })
+                .map(notification -> ServerSentEvent.<Notification>builder()
+                        .event("notification")
+                        .data(notification)
+                        .build());
+    }
+
+    /**
+     * Send a notification to the user using the userId and the notification
+     *
+     * @param userId The userId of the user
+     * @param notification The notification to send
+     */
+    // Send a notification to the user
+    @Override
+    public void sendNotification(UUID userId, Notification notification){
+        FluxSink<Notification> sink = sinks.get(userId);
+        if (sink != null) {
+            sink.next(notification);
+        }
+    }
+
+}

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/StreamService.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/StreamService.java
@@ -1,0 +1,16 @@
+package org.jobspotter.notification.service;
+
+
+import org.jobspotter.notification.model.Notification;
+import org.springframework.http.codec.ServerSentEvent;
+import reactor.core.publisher.Flux;
+
+import java.util.UUID;
+
+public interface StreamService {
+
+    Flux<ServerSentEvent<Notification>> streamNotifications(UUID userId);
+
+    void sendNotification(UUID userId, Notification notification);
+
+}


### PR DESCRIPTION
 This pull request includes several changes to the `jobspotter_backend` service. Enhancing the notification system with streaming capabilities, and updating dependencies. The most important changes are summarized below:


### Notification Streaming:
* Implemented `StreamService` interface and `StreamImpl` class to handle streaming notifications to users using Server-Sent Events (SSE). (`jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/StreamService.java`)
* Updated `NotificationKafkaConsumer` to use `StreamService` for sending notifications. (`jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/Listener/NotificationKafkaConsumer.java`)
* Enhanced `NotificationController` to include endpoints for streaming notifications and simulating notifications. (`jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/controller/NotificationController.java`)

### Dependency Updates:
* Added dependencies for `spring-boot-starter-webflux`, `jjwt-api`, `jjwt-impl`, and `jjwt-jackson` in `notification/pom.xml`. (`jobspotter_backend/services/notification/pom.xml`) [[1]](diffhunk://#diff-83fe147587cc7fce3e8a2a001887d51836a87bd821749dcbd878002067234913L42-R69) [[2]](diffhunk://#diff-83fe147587cc7fce3e8a2a001887d51836a87bd821749dcbd878002067234913R97-R106)
* Removed unnecessary dependencies from `job-post/pom.xml`. (`jobspotter_backend/services/job-post/pom.xml`)

### Model Enhancements:
* Updated `Notification` model to use Lombok annotations for builder pattern and getters. (`jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/Notification.java`)