### PR TITLE
feat: refactor notification handling by removing unused service metho…

### DIFF
--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/Listener/NotificationKafkaConsumer.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/Listener/NotificationKafkaConsumer.java
@@ -18,13 +18,27 @@ public class NotificationKafkaConsumer {
     private final NotificationRepository notificationRepository;
     private final StreamService streamService;
 
+    /**
+     * Consume a notification from Kafka
+     *
+     * @param notification The notification to consume
+     */
     @KafkaListener(topicPattern = ".*", groupId = "${spring.kafka.consumer.group-id}")
     public void consumeNotification(Notification notification) {
         log.info("Received notification: {}", notification);
-        notificationRepository.save(notification).subscribe();
 
-        UUID userId = notification.getSourceUserId();
+        // Save the notification to MongoDB and only proceed when it's saved
+        notificationRepository.save(notification)
+                .doOnSuccess(savedNotification -> {
+                    log.info("Saved Notification: {}", savedNotification);
 
-        streamService.sendNotification(userId, notification);
+                    // Get userId from the saved notification
+                    UUID userId = savedNotification.getDestinationUserId();
+
+                    // Send the notification to the user with the saved notification (including generated ID & createdAt)
+                    streamService.sendNotification(userId, savedNotification);
+                })
+                .doOnError(error -> log.error("Error saving notification: {}", error.getMessage()))
+                .subscribe();
     }
 }

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/controller/NotificationController.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/controller/NotificationController.java
@@ -24,18 +24,7 @@ import java.util.UUID;
 public class NotificationController {
 
     private final StreamService streamService;
-    private final NotificationService notificationService;
 
-    @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public Mono<Notification> createNotification(@RequestBody Notification notification) {
-        return notificationService.sendNotification(notification);
-    }
-
-    @GetMapping
-    public Flux<Notification> getAllNotifications() {
-        return notificationService.getAllNotifications();
-    }
 
 
     @GetMapping("/stream")

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/Notification.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/Notification.java
@@ -1,4 +1,5 @@
 package org.jobspotter.notification.model;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -12,6 +13,7 @@ import java.util.UUID;
 @Getter
 @Builder
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @NoArgsConstructor
 @AllArgsConstructor
 public class Notification {

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/Implementation/NotificationServiceImpl.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/Implementation/NotificationServiceImpl.java
@@ -14,13 +14,5 @@ public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationRepository notificationRepository;
 
-    @Override
-    public Mono<Notification> sendNotification(Notification notification) {
-        return notificationRepository.save(notification);
-    }
 
-    @Override
-    public Flux<Notification> getAllNotifications() {
-        return notificationRepository.findAll();
-    }
 }

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/NotificationService.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/NotificationService.java
@@ -5,7 +5,5 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface NotificationService {
-    Mono<Notification> sendNotification(Notification notification);
 
-    Flux<Notification> getAllNotifications();
 }


### PR DESCRIPTION

This pull request includes several significant changes to the notification service in the `jobspotter_backend` project. The changes involve improving the Kafka consumer logic, simplifying the notification controller, and updating the notification model. Below are the most important changes:

### Kafka Consumer Improvements:

* Enhanced the `consumeNotification` method in `NotificationKafkaConsumer` to ensure notifications are saved to MongoDB before sending them, and added error handling for save operations (`jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/Listener/NotificationKafkaConsumer.java`).

### Controller Simplification:

* Removed the `createNotification` and `getAllNotifications` endpoints from `NotificationController`, which simplifies the controller by focusing on the remaining endpoints (`jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/controller/NotificationController.java`).

### Model Update:

* Added `@JsonInclude(JsonInclude.Include.NON_NULL)` to the `Notification` class to exclude null fields from JSON serialization (`jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/model/Notification.java`).

### Service Cleanup:

* Removed the `sendNotification` and `getAllNotifications` methods from `NotificationService` and their implementations in `NotificationServiceImpl`, as these functionalities are no longer needed (`jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/NotificationService.java`, `jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/Implementation/NotificationServiceImpl.java`). [[1]](diffhunk://#diff-1a774deecfeae4045a6b610c14450a80beec12686c5e72ca7b734356feccd24dL8-L10) [[2]](diffhunk://#diff-3779260a9ad8b0c792d48308626ad459e7a6d30d3e1496f264d124305e8a40c8L17-L25)