### PR TITLE
feat: update notification handling to support marking as read or unread

### DIFF
--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/controller/NotificationController.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/controller/NotificationController.java
@@ -62,7 +62,7 @@ public class NotificationController {
 //------------------------------------------------------------------------------------------------------------------
 
     @Operation(
-            summary = "Mark a notification as read",
+            summary = "Mark a notification as read or unread",
             description = "Mark a notification as read using the notification ID" +
                     "The user must be authenticated to access this endpoint"
     )
@@ -78,15 +78,15 @@ public class NotificationController {
                     content = @io.swagger.v3.oas.annotations.media.Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponse.class)))
             }
     )
-    @GetMapping("/{notificationId}/mark-as-read")
+    @GetMapping("/{notificationId}/mark-read-or-unread")
     public Mono<ResponseEntity<Object>> markNotificationAsRead(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable String notificationId
     ) throws Exception {
         UUID userId = JWTUtils.getUserIdFromToken(accessToken);
 
-        return notificationService.markNotificationAsRead(userId, notificationId)
-                .then(Mono.just(ResponseEntity.ok((Object)"Notification marked as unread.")))
+        return notificationService.markNotificationAsReadOrUnread(userId, notificationId)
+                .then(Mono.just(ResponseEntity.noContent().build()))
                 .onErrorResume(ResourceNotFoundException.class, e ->
                         Mono.just(ResponseEntity.status(HttpStatus.NOT_FOUND)
                                 .body(new ErrorResponse(e.getMessage()))))

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/Implementation/NotificationServiceImpl.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/Implementation/NotificationServiceImpl.java
@@ -22,7 +22,7 @@ public class NotificationServiceImpl implements NotificationService {
 //                                           Notification update methods
 //---------------------------------------------------------------------------------------------------------
     /**
-     * Mark a notification as unread using the notificationId
+     * Mark a notification as read using the notificationId
      * Check if the notification exists, then mark it as unread
      * Return a Mono error if the notification does not exist or the user is not authorized
      *
@@ -32,13 +32,18 @@ public class NotificationServiceImpl implements NotificationService {
      */
     // Mark a notification as unread
     @Override
-    public Mono<Void> markNotificationAsRead(UUID userId, String notificationId) {
+    public Mono<Void> markNotificationAsReadOrUnread(UUID userId, String notificationId) {
         return verifyNotificationAndAuthorization(notificationId, userId)
                 .flatMap(notification -> {
+                    if(notification.isRead()) {
+                        notification.setRead(false);
+                        return notificationRepository.save(notification).then();
+                    }
                     notification.setRead(true);
                     return notificationRepository.save(notification).then();
                 });
     }
+
 //---------------------------------------------------------------------------------------------------------
 //                                                Helper methods
 //---------------------------------------------------------------------------------------------------------

--- a/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/NotificationService.java
+++ b/jobspotter_backend/services/notification/src/main/java/org/jobspotter/notification/service/NotificationService.java
@@ -10,5 +10,6 @@ public interface NotificationService {
 
 
     //Notification update methods
-    Mono<Void> markNotificationAsRead(UUID userId, String notificationId);
+    Mono<Void> markNotificationAsReadOrUnread(UUID userId, String notificationId);
+
 }


### PR DESCRIPTION
This pull request includes changes to the notification marking functionality in the `jobspotter_backend` service. The main change is the enhancement of the existing "mark as read" feature to also allow notifications to be marked as unread. This involves modifications to the controller, service implementation, and interface.
