### PR TITLE
feat: Refactor address update methods to return AddressResponse and i…

### DIFF
--- a/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/controller/AddressController.java
+++ b/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/controller/AddressController.java
@@ -100,13 +100,14 @@ public class AddressController {
             )
     })
     @PatchMapping("/{addressId}")
-    public ResponseEntity<?> updateAddress(
+    public ResponseEntity<AddressResponse> updateAddress(
             @RequestHeader("Authorization") String accessToken,
             @PathVariable Long addressId,
             @RequestBody @Valid AddressPatchRequest addressRequest
     ) throws Exception {
 
-        return addressService.updateAddress(accessToken, addressId, addressRequest);
+        AddressResponse addressResponse = addressService.updateAddress(accessToken, addressId, addressRequest);
+        return addressResponse != null ? ResponseEntity.ok(addressResponse) : ResponseEntity.noContent().build();
 
     }
 

--- a/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/AddressService.java
+++ b/jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/AddressService.java
@@ -31,7 +31,7 @@ public interface AddressService {
      * @param addressRequest the address request
      * @return the updated address, error response or no content
      */
-    ResponseEntity<?> updateAddress(String accessToken, Long addressId, AddressPatchRequest addressRequest) throws Exception;
+    AddressResponse updateAddress(String accessToken, Long addressId, AddressPatchRequest addressRequest) throws Exception;
 
     /**
      * Get an address by id

--- a/jobspotter_backend/services/user/src/test/java/org/jobspotter/user/unit/AddressServiceImplUnitTests.java
+++ b/jobspotter_backend/services/user/src/test/java/org/jobspotter/user/unit/AddressServiceImplUnitTests.java
@@ -121,7 +121,7 @@ class AddressServiceImplUnitTests {
                 .city(addressRequest.getCity())
                 .county(addressRequest.getCounty())
                 .eirCode(addressRequest.getEirCode())
-                .addressType(AddressType.WORK)
+                .addressType(addressRequest.getAddressType())
                 .isDefault(addressRequest.isDefault())
                 .build();
 
@@ -261,9 +261,16 @@ class AddressServiceImplUnitTests {
             when(geoCodingService.getCoordinates(anyString())).thenReturn(Map.of("lat", 3.0, "lng", 4.0));
             when(addressRepository.save(any(Address.class))).thenReturn(address);
 
-            ResponseEntity<?> response = addressService.updateAddress(accessToken, 1L, addressPatchRequest);
+            AddressResponse res = addressService.updateAddress(accessToken, 1L, addressPatchRequest);
 
-            assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+            assertEquals(1L, res.getAddressId());
+            assertEquals(addressPatchRequest.getStreetAddress(), res.getStreetAddress());
+            assertEquals(addressPatchRequest.getCity(), res.getCity());
+            assertEquals(addressPatchRequest.getCounty(), res.getCounty());
+            assertEquals(addressPatchRequest.getEirCode(), res.getEirCode());
+            assertEquals(addressPatchRequest.getAddressType(), res.getAddressType());
+            assertEquals(addressPatchRequest.isDefault(), res.isDefault());
+
             verify(addressRepository, times(1)).save(any(Address.class));
         }
     }


### PR DESCRIPTION
This pull request includes several changes to the `AddressService` and related classes in the `jobspotter_backend` to improve the handling of address updates. The most important changes include modifying the return type of the `updateAddress` method, refactoring the address update logic, and updating the corresponding unit tests.

Changes to method return types and response handling:

* [`jobspotter_backend/services/user/src/main/java/org/jobspotter/user/controller/AddressController.java`](diffhunk://#diff-a5863cf4d2feb68e8ebf3e81309b16b7de16b189bbdc51f7a5971fc264f182efL103-R110): Changed the return type of `updateAddress` from `ResponseEntity<?>` to `ResponseEntity<AddressResponse>` and updated the response handling logic.
* [`jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/AddressService.java`](diffhunk://#diff-83b3b954d448408b0a7e8259df113ece58d8df98d3bc7dafc7ced32fc181ddd9L34-R34): Modified the `updateAddress` method's return type from `ResponseEntity<?>` to `AddressResponse`.
* [`jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/implementation/AddressServiceImpl.java`](diffhunk://#diff-a6c7b4cb07194a2b58499c41543e1ac326e263b63c94faf11c7596c0d40fd73aL134-R134): Updated the `updateAddress` method to return an `AddressResponse` object instead of `ResponseEntity<?>`.

Refactoring and improvements to address update logic:

* [`jobspotter_backend/services/user/src/main/java/org/jobspotter/user/service/implementation/AddressServiceImpl.java`](diffhunk://#diff-a6c7b4cb07194a2b58499c41543e1ac326e263b63c94faf11c7596c0d40fd73aL166-R166): Removed the creation of a new `Address` object and directly updated the `unwrappedAddress` object. Also, updated the handling of duplicate addresses and address type conflicts. [[1]](diffhunk://#diff-a6c7b4cb07194a2b58499c41543e1ac326e263b63c94faf11c7596c0d40fd73aL166-R166) [[2]](diffhunk://#diff-a6c7b4cb07194a2b58499c41543e1ac326e263b63c94faf11c7596c0d40fd73aL188-R207) [[3]](diffhunk://#diff-a6c7b4cb07194a2b58499c41543e1ac326e263b63c94faf11c7596c0d40fd73aL302-R302)

Updates to unit tests:

* [`jobspotter_backend/services/user/src/test/java/org/jobspotter/user/unit/AddressServiceImplUnitTests.java`](diffhunk://#diff-00b49970baaf65bcad25f553f1b3d3b88fd4cb0263cf3983656770ee4ee9d1afL264-L266): Modified the `updateAddress_success` test to assert the fields of the returned `AddressResponse` object and removed the assertion for the `HttpStatus.NO_CONTENT` response.
* [`jobspotter_backend/services/user/src/test/java/org/jobspotter/user/unit/AddressServiceImplUnitTests.java`](diffhunk://#diff-00b49970baaf65bcad25f553f1b3d3b88fd4cb0263cf3983656770ee4ee9d1afL124-R124): Updated the `setUp` method to use the address type from the `addressRequest`.