### PR TITLE
Jobspotter 146 distributed tracing for backend

### DIFF
--- a/jobspotter_backend/docker-compose.yml
+++ b/jobspotter_backend/docker-compose.yml
@@ -120,6 +120,16 @@ services:
     networks:
       - jobSpotter-net
 
+#        ----------------------Tools--------------------------
+  #----------------------Zipkin------------------------
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: jobSpotter_zipkin
+    ports:
+      - "9411:9411"  # Expose Zipkin UI on port 9411
+    networks:
+      - jobSpotter-net
+
 #        ----------------------Network------------------------
 
 

--- a/jobspotter_backend/services/config-server/src/main/resources/configurations/application.properties
+++ b/jobspotter_backend/services/config-server/src/main/resources/configurations/application.properties
@@ -12,3 +12,7 @@ eureka.instance.prefer-ip-address=true
 
 # preventing micro-services from overriding default properties
 spring.cloud.config.override-system-properties=false
+
+
+#-----------------------------------Zipkin----------------------------------------#
+management.tracing.sampling.probability=1.0

--- a/jobspotter_backend/services/discovery/pom.xml
+++ b/jobspotter_backend/services/discovery/pom.xml
@@ -45,6 +45,14 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/jobspotter_backend/services/gateway/pom.xml
+++ b/jobspotter_backend/services/gateway/pom.xml
@@ -63,7 +63,19 @@
 			<artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
 			<version>2.6.0</version>
 		</dependency>
-    </dependencies>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+	</dependencies>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/jobspotter_backend/services/job-post/pom.xml
+++ b/jobspotter_backend/services/job-post/pom.xml
@@ -156,6 +156,24 @@
 		</dependency>
 
 
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.openfeign</groupId>
+			<artifactId>feign-micrometer</artifactId>
+		</dependency>
+
+
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/jobspotter_backend/services/notification/pom.xml
+++ b/jobspotter_backend/services/notification/pom.xml
@@ -115,6 +115,24 @@
 			<version>0.12.6</version>
 			<scope>compile</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.openfeign</groupId>
+			<artifactId>feign-micrometer</artifactId>
+		</dependency>
+
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/jobspotter_backend/services/notification/pom.xml
+++ b/jobspotter_backend/services/notification/pom.xml
@@ -128,10 +128,7 @@
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing-bridge-brave</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>io.github.openfeign</groupId>
-			<artifactId>feign-micrometer</artifactId>
-		</dependency>
+
 
 	</dependencies>
 	<dependencyManagement>

--- a/jobspotter_backend/services/report/pom.xml
+++ b/jobspotter_backend/services/report/pom.xml
@@ -108,10 +108,7 @@
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing-bridge-brave</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>io.github.openfeign</groupId>
-			<artifactId>feign-micrometer</artifactId>
-		</dependency>
+
 
 	</dependencies>
 	<dependencyManagement>

--- a/jobspotter_backend/services/report/pom.xml
+++ b/jobspotter_backend/services/report/pom.xml
@@ -95,6 +95,24 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.6.0</version>
 		</dependency>
+
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.openfeign</groupId>
+			<artifactId>feign-micrometer</artifactId>
+		</dependency>
+
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/jobspotter_backend/services/review/pom.xml
+++ b/jobspotter_backend/services/review/pom.xml
@@ -136,6 +136,23 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.openfeign</groupId>
+			<artifactId>feign-micrometer</artifactId>
+		</dependency>
+
     </dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/jobspotter_backend/services/user/pom.xml
+++ b/jobspotter_backend/services/user/pom.xml
@@ -164,6 +164,22 @@
 			<artifactId>s3</artifactId>
 			<version>2.30.34</version>
 		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.openfeign</groupId>
+			<artifactId>feign-micrometer</artifactId>
+		</dependency>
 
 	</dependencies>
 	<dependencyManagement>


### PR DESCRIPTION
This pull request introduces Zipkin for distributed tracing to the JobSpotter backend services. The main changes involve adding Zipkin dependencies to various service configuration files and updating the `docker-compose.yml` to include a Zipkin service.

### Zipkin Integration:

* [`jobspotter_backend/docker-compose.yml`](diffhunk://#diff-a5c43cec0d63e96e58f230facc888acd03b72e2e9ea33f256738a49447639cebR123-R132): Added a new Zipkin service configuration to the Docker Compose file, exposing the Zipkin UI on port 9411.

* [`jobspotter_backend/services/config-server/src/main/resources/configurations/application.properties`](diffhunk://#diff-d742883ec84b322a4743e651876ef53f085e4362d4d2e0d741d678df88055e8bR15-R18): Added configuration for Zipkin tracing with a sampling probability of 1.0.

### Dependencies Update:

* [`jobspotter_backend/services/discovery/pom.xml`](diffhunk://#diff-a95f83d7fbc9d9a131bda1e5d45cb9f584eecb5983b380ab33fddae76bb46b8aR48-R55): Added dependencies for `zipkin-reporter-brave` and `micrometer-tracing-bridge-brave`.
* [`jobspotter_backend/services/gateway/pom.xml`](diffhunk://#diff-7c4db3b19bb26b07a581a674ee3e070093220f469e791b96667b6d105b9cfe78R66-R77): Added dependencies for `zipkin-reporter-brave`, `spring-boot-starter-actuator`, and `micrometer-tracing-bridge-brave`.
* [`jobspotter_backend/services/job-post/pom.xml`](diffhunk://#diff-f0b5d2a5fce65f9358620e844e457751f09e0e7c5d464d42bc6aa987f9714b6bR159-R176): Added dependencies for `zipkin-reporter-brave`, `spring-boot-starter-actuator`, `micrometer-tracing-bridge-brave`, and `feign-micrometer`.
* [`jobspotter_backend/services/notification/pom.xml`](diffhunk://#diff-83fe147587cc7fce3e8a2a001887d51836a87bd821749dcbd878002067234913R118-R132): Added dependencies for `zipkin-reporter-brave`, `spring-boot-starter-actuator`, and `micrometer-tracing-bridge-brave`.
* [`jobspotter_backend/services/report/pom.xml`](diffhunk://#diff-1f6c4cd7cc2b5be0eab816eb19ac8e130f9fb9c23e1d1e3708123b68d280e3aaR98-R112): Added dependencies for `zipkin-reporter-brave`, `spring-boot-starter-actuator`, and `micrometer-tracing-bridge-brave`.
* [`jobspotter_backend/services/review/pom.xml`](diffhunk://#diff-3c45731bcd969835ae8a72b55a2f02a55f7b002ef49016305ef55a295802dae9R139-R155): Added dependencies for `zipkin-reporter-brave`, `spring-boot-starter-actuator`, `micrometer-tracing-bridge-brave`, and `feign-micrometer`.
* [`jobspotter_backend/services/user/pom.xml`](diffhunk://#diff-a4c5e63dc616f50ee0919864bae160beaddc066575eeee9db5211e335209c453R167-R182): Added dependencies for `zipkin-reporter-brave`, `spring-boot-starter-actuator`, `micrometer-tracing-bridge-brave`, and `feign-micrometer`.