### PR TITLE
Jobspotter 99 unit tests for job post service back end

### DIFF
--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java
@@ -198,9 +198,8 @@ public class JobPostController {
             @RequestParam(defaultValue = "10") int size
     ) throws Exception {
         log.info("Getting my job posts");
-        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
 
-        return ResponseEntity.ok(jobPostService.searchMyJobPosts(userId, title, tags, status, pageNumber, size));
+        return ResponseEntity.ok(jobPostService.searchMyJobPosts(accessToken, title, tags, status, pageNumber, size));
     }
 
 
@@ -222,7 +221,7 @@ public class JobPostController {
         log.info("Getting my worked jobs");
         UUID userId = JWTUtils.getUserIdFromToken(accessToken);
 
-        return ResponseEntity.ok(jobPostService.searchJobsUserWorkedOn(userId, title, status, sortBy, sortDirection, page, size));
+        return ResponseEntity.ok(jobPostService.searchJobsUserWorkedOn(accessToken, title, status, sortBy, sortDirection, page, size));
     }
 
     //-----------------------------------------------------------------------------------------------------------------

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/AddressResponse.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/AddressResponse.java
@@ -1,12 +1,14 @@
 package org.job_spotter.jobpost.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@Builder
 public class AddressResponse {
 
     private String address;

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/JobPostPostRequest.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/JobPostPostRequest.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.job_spotter.jobpost.dto.deserializer.TagDeserializer;
@@ -16,6 +17,7 @@ import java.util.Set;
 
 @Getter
 @Setter
+@Builder
 public class JobPostPostRequest {
 
 

--- a/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/JobPostService.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/JobPostService.java
@@ -2,10 +2,8 @@ package org.job_spotter.jobpost.service;
 
 import org.job_spotter.jobpost.dto.*;
 import org.job_spotter.jobpost.model.Applicant;
-import org.job_spotter.jobpost.model.JobPost;
 import org.job_spotter.jobpost.model.JobStatus;
 import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
 
 import java.util.List;
 import java.util.UUID;
@@ -21,9 +19,9 @@ public interface JobPostService {
     //Job Post Search Queries
     Page<JobPostSearchResponse> searchJobPosts(String title, String tags, Double latitude, Double longitude, Double radius, int pageNumber, int pageSize);
 
-    Page<MyJobPostSearchResponse> searchMyJobPosts(UUID userId, String title, String tags, String status, int page, int size);
+    Page<MyJobPostSearchResponse> searchMyJobPosts(String accessToken, String title, String tags, String status, int page, int size) throws Exception;
 
-    Page<JobPostsUserWorkedOnSearchResponse> searchJobsUserWorkedOn(UUID userId, String title, String status, String sortBy, String sortDirection, int page, int size);
+    Page<JobPostsUserWorkedOnSearchResponse> searchJobsUserWorkedOn(String accessToken, String title, String status, String sortBy, String sortDirection, int page, int size) throws Exception;
 
     //Job Post Operations
     Long createJobPost(String accessToken, JobPostPostRequest jobPostPostRequest);
@@ -32,19 +30,19 @@ public interface JobPostService {
 
     void deleteJobPost(String accessToken, Long jobPostId) throws Exception;
 
-    HttpStatus applyToJobPost(UUID userId, Long jobPostId, JobPostApplyRequest jobPostApplyRequest);
+    void applyToJobPost(UUID userId, Long jobPostId, JobPostApplyRequest jobPostApplyRequest);
 
-    JobPost takeApplicantsAction(UUID userId, Long jobPostId, List<ApplicantActionRequest> applicantsActionRequest);
+    void takeApplicantsAction(UUID userId, Long jobPostId, List<ApplicantActionRequest> applicantsActionRequest);
 
     void updateApplicantMessage(String accessToken, Long jobPostId, Long applicantId, String message) throws Exception;
 
     void deleteApplicant(String accessToken, Long jobPostId, Long applicantId) throws Exception;
 
-    HttpStatus startJobPost(UUID userId, Long jobPostId) ;
+    void startJobPost(UUID userId, Long jobPostId) ;
 
-    HttpStatus cancelJobPost(String accessToken, Long jobPostId) throws Exception;
+    void cancelJobPost(String accessToken, Long jobPostId) throws Exception;
 
-    HttpStatus finishJobPost(UUID userId, Long jobPostId);
+    void finishJobPost(UUID userId, Long jobPostId);
 
     Applicant getApplicantById(String accessToken, Long applicantId) throws Exception;
 

--- a/jobspotter_backend/services/job-post/src/test/java/org/job_spotter/jobpost/UnitTests/JobPostServiceImplTests.java
+++ b/jobspotter_backend/services/job-post/src/test/java/org/job_spotter/jobpost/UnitTests/JobPostServiceImplTests.java
@@ -1,9 +1,12 @@
 package org.job_spotter.jobpost.UnitTests;
 
+import feign.FeignException;
+import feign.Request;
+import feign.RequestTemplate;
 import org.job_spotter.jobpost.authUtils.JWTUtils;
 import org.job_spotter.jobpost.client.UserServiceClient;
-import org.job_spotter.jobpost.dto.JobPostDetailedResponse;
-import org.job_spotter.jobpost.dto.JobPostSearchResponse;
+import org.job_spotter.jobpost.dto.*;
+import org.job_spotter.jobpost.exception.ForbiddenException;
 import org.job_spotter.jobpost.exception.InvalidRequestException;
 import org.job_spotter.jobpost.exception.ResourceNotFoundException;
 import org.job_spotter.jobpost.exception.UnauthorizedException;
@@ -23,16 +26,23 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
+
+import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.MockedStatic;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 
 /**
  * Unit tests for {@link JobPostImpl#getJobPostById(Long)} method.
@@ -60,6 +70,7 @@ public class JobPostServiceImplTests {
 
     @InjectMocks
     private JobPostImpl jobPostImpl;
+
 
     //==================================================================================================================
     //                                     TESTS FOR MAIN JOB POST SERVICE METHODS
@@ -90,7 +101,17 @@ public class JobPostServiceImplTests {
         assertAll("Verify JobPostDetailedResponse",
                 () -> assertEquals(expectedJobPost.getJobPostId(), respondedJobPost.getJobPostId()),
                 () -> assertEquals(expectedJobPost.getJobPosterId(), respondedJobPost.getJobPosterId()),
-                () -> assertEquals(expectedJobPost.getTags(), respondedJobPost.getTags()),
+                () -> {
+                    Set<String> expectedTagNames = expectedJobPost.getTags().stream()
+                            .map(Tag::getName)
+                            .collect(Collectors.toSet());
+
+                    Set<String> actualTagNames = respondedJobPost.getTags().stream()
+                            .map(TagDto::getName)
+                            .collect(Collectors.toSet());
+
+                    assertEquals(expectedTagNames, actualTagNames);
+                },
                 () -> assertEquals(expectedJobPost.getTitle(), respondedJobPost.getTitle()),
                 () -> assertEquals(expectedJobPost.getDescription(), respondedJobPost.getDescription()),
                 () -> assertEquals(expectedJobPost.getAddress(), respondedJobPost.getAddress()),
@@ -149,7 +170,7 @@ public class JobPostServiceImplTests {
         // Stub repository to return our dummy job post.
         when(jobPostRepository.findById(1L)).thenReturn(Optional.of(testJobPost));
 
-        try(MockedStatic<JWTUtils> jwtUtilsMockedStatic = Mockito.mockStatic(JWTUtils.class)){
+        try(MockedStatic<JWTUtils> jwtUtilsMockedStatic = mockStatic(JWTUtils.class)){
 
             adminJobPosterTestToggle(isAdmin, testJobPost, jwtUtilsMockedStatic, accessToken);
 
@@ -194,7 +215,7 @@ public class JobPostServiceImplTests {
 
         JobPost jobPost = getDummyJobPost();
 
-        try(MockedStatic<JWTUtils> jwtUtilsMockedStatic = Mockito.mockStatic(JWTUtils.class)) {
+        try(MockedStatic<JWTUtils> jwtUtilsMockedStatic = mockStatic(JWTUtils.class)) {
             // Arrange: Create a dummy job post.
             String accessToken = "dummyToken";
 
@@ -234,7 +255,7 @@ public class JobPostServiceImplTests {
      */
     @ParameterizedTest(name = "#{0} - {1}")
     @MethodSource("searchJobPostsTestParameters")
-    void searchJobPosts_success(int testnumber, String testName, String title, String tags, Double latitude, Double longitude, Double radius, Integer pageNumber, Integer pageSize, boolean expectException) {
+    void searchJobPosts_success(int testnumber, String testName, String title, String tags, Double latitude, Double longitude, Double radius, Integer pageNumber, Integer pageSize) {
 
 
         int totalNumberOfJobPosts = 5;
@@ -265,14 +286,19 @@ public class JobPostServiceImplTests {
                 () -> assertEquals(jobPost.getLongitude(), result.getLongitude()),
                 () -> assertEquals(jobPost.getLatitude(), result.getLatitude()),
                 () -> assertEquals(jobPost.getMaxApplicants(), result.getMaxApplicants()),
-                () -> assertEquals(jobPost.getStatus(), result.getStatus())
+                () -> assertEquals(jobPost.getStatus(), result.getStatus()),
+                () -> assertEquals(jobPost.getApplicants().size(), result.getApplicantsCount())
         );
+
 
         verify(jobPostSpecificationRepository).findAll(any(Specification.class), any(PageRequest.class));
 
 
 
     }
+
+
+
 
     /**
      * Testing for a Invalid page number or page size scenario.
@@ -311,21 +337,22 @@ public class JobPostServiceImplTests {
         JobPost jobPost = getDummyJobPost();
         jobPost.setStatus(JobStatus.CANCELLED);
 
-        // Stub the repository call
+        // Stub the repository call to return an empty page (simulating filtering of non-OPEN jobs)
         when(jobPostSpecificationRepository.findAll(
                 any(Specification.class), any(Pageable.class))
-        ).thenReturn(new PageImpl<>(List.of(jobPost)));
+        ).thenReturn(new PageImpl<>(Collections.emptyList()));
 
         // Act: Call the search method.
         Page<JobPostSearchResponse> response = jobPostImpl.searchJobPosts("Test", "OTHER", 10.0, 20.0, 10.0, 0, 5);
 
-        System.out.println(response.getContent().get(0));
         // Assert
         assertNotNull(response);
         assertEquals(0, response.getTotalElements());
 
         verify(jobPostSpecificationRepository).findAll(any(Specification.class), any(PageRequest.class));
     }
+
+
     //Test Methods for SearchMyJobPosts
     //==================================================================================================================
 
@@ -337,8 +364,1006 @@ public class JobPostServiceImplTests {
      * </p>
      */
 
+    @ParameterizedTest(name = "#{0} - {1}")
+    @MethodSource("searchMyJobPostsTestParameters")
+    void searchMyJobPosts_Success(int testNumber, String testName, String title, String tags, String status, int pageNumber, int pageSize) throws Exception {
+        String accessToken = "dummyToken";
+        UUID userId = UUID.randomUUID();
 
+        int totalJobPosts = 3;
+        Page<JobPost> page = getDummyJobPostsPage(totalJobPosts);
+        JobPost jobPost = page.getContent().getFirst();
 
+        try (MockedStatic<JWTUtils> jwtUtilsMockedStatic = mockStatic(JWTUtils.class)) {
+            jwtUtilsMockedStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
+
+            when(jobPostSpecificationRepository.findAll(
+                    any(Specification.class), any(Pageable.class))
+            ).thenReturn(page);
+
+            Page<MyJobPostSearchResponse> response = jobPostImpl.searchMyJobPosts(accessToken, title, tags, status, pageNumber, pageSize);
+
+            assertNotNull(response);
+            assertEquals(totalJobPosts, response.getTotalElements());
+
+            MyJobPostSearchResponse result = response.getContent().getFirst();
+
+            assertAll("Verify MyJobPostSearchResponse",
+                    () -> assertEquals(jobPost.getJobPostId(), result.getJobPostId()),
+                    () -> assertEquals(jobPost.getTags(), result.getTags()),
+                    () -> assertEquals(jobPost.getTitle(), result.getTitle()),
+                    () -> assertEquals(jobPost.getDescription(), result.getDescription()),
+                    () -> assertEquals(jobPost.getAddress(), result.getAddress()),
+                    () -> assertEquals(jobPost.getDatePosted(), result.getDatePosted()),
+                    () -> assertEquals(jobPost.getLastUpdatedAt(), result.getLastUpdatedAt()),
+                    () -> assertEquals(jobPost.getApplicants().size(), result.getApplicantsCount()),
+                    () -> assertEquals(jobPost.getMaxApplicants(), result.getMaxApplicants()),
+                    () -> assertEquals(jobPost.getStatus(), result.getStatus())
+            );
+        }
+    }
+
+    /**
+     * Testing for a Invalid page number or page size scenario.
+     *
+     * <p>
+     *     Given a valid job post exists in the repository,
+     *     when searchMyJobPosts is called with invalid page number or page size then an InvalidRequestException is thrown.
+     * </p>
+     *
+     */
+
+    @Test
+    void searchMyJobPosts_InvalidPageNumberOrSize() throws Exception {
+        String accessToken = "dummyToken";
+        try (MockedStatic<JWTUtils> jwtUtilsMockedStatic = mockStatic(JWTUtils.class)) {
+            jwtUtilsMockedStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(UUID.randomUUID());
+
+            assertThrows(InvalidRequestException.class,
+                    () -> jobPostImpl.searchMyJobPosts(accessToken, "Title", "OTHER", "OPEN", -1, 10));
+
+            assertThrows(InvalidRequestException.class,
+                    () -> jobPostImpl.searchMyJobPosts(accessToken, "Title", "OTHER", "OPEN", 0, 0));
+        }
+    }
+
+    // Test Methods for searchJobsUserWorkedOn
+    //=================================================================================================================='
+
+    /**
+     * Testing for a successful search of job posts by the user.
+     * <p>
+     * Given a valid job post exists in the repository,
+     * when searchJobsUserWorkedOn is called then a detailed response is returned with the correct values.
+     * </p>
+     */
+    @ParameterizedTest(name = "#{0} - {1}")
+    @MethodSource("searchJobsUserWorkedOnTestParameters")
+    void searchJobsUserWorkedOn_Success(int testNumber, String testName, String title, String status, String sortBy, String sortDirection, int page, int size) throws Exception {
+        String accessToken = "dummyToken";
+        UUID userId = UUID.randomUUID();
+
+        Page<JobPost> dummyPage = getDummyJobPostsPageWithApplicant(3, userId);  // helper returns JobPosts where user is an applicant
+        JobPost jobPost = dummyPage.getContent().getFirst();
+
+        try (MockedStatic<JWTUtils> jwtUtilsMockedStatic = mockStatic(JWTUtils.class)) {
+            jwtUtilsMockedStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
+
+            when(jobPostSpecificationRepository.findAll(any(Specification.class), any(Pageable.class)))
+                    .thenReturn(dummyPage);
+
+            Page<JobPostsUserWorkedOnSearchResponse> response = jobPostImpl.searchJobsUserWorkedOn(
+                    accessToken, title, status, sortBy, sortDirection, page, size);
+
+            assertNotNull(response);
+            assertEquals(3, response.getTotalElements());
+
+            JobPostsUserWorkedOnSearchResponse result = response.getContent().getFirst();
+
+            assertAll("Verify JobPostsUserWorkedOnSearchResponse mapping",
+                    () -> assertEquals(jobPost.getJobPostId(), result.getJobPostId()),
+                    () -> assertEquals(jobPost.getTags(), result.getTags()),
+                    () -> assertEquals(jobPost.getTitle(), result.getTitle()),
+                    () -> assertEquals(jobPost.getDescription(), result.getDescription()),
+                    () -> assertEquals(jobPost.getAddress(), result.getAddress()),
+                    () -> assertEquals(jobPost.getDatePosted(), result.getDatePosted()),
+                    () -> assertEquals(jobPost.getLastUpdatedAt(), result.getLastUpdatedAt()),
+                    () -> assertEquals(jobPost.getApplicants().size(), result.getApplicantsCount()),
+                    () -> assertEquals(jobPost.getMaxApplicants(), result.getMaxApplicants()),
+                    () -> assertEquals(JobStatus.OPEN, result.getStatus()),
+                    () -> assertEquals(ApplicantStatus.PENDING, result.getApplicantStatus()),
+                    () -> assertNotNull(result.getDateApplied()),
+                    () -> assertNotNull(result.getLastApplicantStatusChange())
+            );
+        }
+    }
+
+    /**
+     * Testing for a Invalid page number or page size scenario.
+     *
+     * <p>
+     *     Given a valid job post exists in the repository,
+     *     when searchJobsUserWorkedOn is called with invalid page number or page size then an InvalidRequestException is thrown.
+     * </p>
+     *
+     */
+    @Test
+    void searchJobsUserWorkedOn_InvalidSortBy_ThrowsException() {
+        String accessToken = "dummyToken";
+
+        try (MockedStatic<JWTUtils> jwtUtilsMockedStatic = mockStatic(JWTUtils.class)) {
+            jwtUtilsMockedStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(UUID.randomUUID());
+
+            InvalidRequestException exception = assertThrows(InvalidRequestException.class, () ->
+                    jobPostImpl.searchJobsUserWorkedOn(accessToken, null, null, "invalidSort", "asc", 0, 5));
+
+            assertTrue(exception.getMessage().contains("Invalid sortBy parameter"));
+        }
+    }
+
+    // Test Methods for createJobPost
+    //==================================================================================================================
+
+    /**
+     * Testing for a successful creation of a job post.
+     * <p>
+     * Given a valid job post request,
+     * when createJobPost is called then the job post is created successfully and the ID is returned.
+     * </p>
+     */
+    @Test
+    void createJobPost_Success() {
+        String accessToken = "dummyAccessToken";
+        UUID userId = UUID.randomUUID();
+
+        JobPostPostRequest request = getDummyJobPostPostRequest();
+        AddressResponse addressResponse = getDummyAddressResponse();
+
+        // Mock token decoding and address fetch
+        try (MockedStatic<JWTUtils> jwtUtilsMocked = mockStatic(JWTUtils.class)) {
+            jwtUtilsMocked.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
+            when(userServiceClient.getAddressById(accessToken, request.getAddressId()))
+                    .thenReturn(ResponseEntity.ok(addressResponse));
+
+            // Mock the save to return the job post with an ID
+            ArgumentCaptor<JobPost> jobPostCaptor = ArgumentCaptor.forClass(JobPost.class);
+            when(jobPostRepository.save(any(JobPost.class))).thenAnswer(invocation -> {
+                JobPost savedPost = invocation.getArgument(0);
+                savedPost.setJobPostId(99L);
+                return savedPost;
+            });
+
+            Long returnedId = jobPostImpl.createJobPost(accessToken, request);
+
+            assertNotNull(returnedId);
+            assertEquals(99L, returnedId);
+
+            verify(jobPostRepository).save(jobPostCaptor.capture());
+            JobPost savedJob = jobPostCaptor.getValue();
+
+            assertAll("Verify saved job post",
+                    () -> assertEquals(userId, savedJob.getJobPosterId()),
+                    () -> assertEquals("New Job Post", savedJob.getTitle()),
+                    () -> assertEquals("Looking for a skilled worker", savedJob.getDescription()),
+                    () -> assertEquals("123 Main St", savedJob.getAddress()),
+                    () -> assertEquals(JobStatus.OPEN, savedJob.getStatus())
+            );
+        }
+    }
+
+    /**
+     * Testing for an invalid request scenario.
+     * <p>
+     * Given an invalid job post request,
+     * when createJobPost is called then an InvalidRequestException is thrown.
+     * </p>
+     */
+    @Test
+    void createJobPost_InvalidAddress_ThrowsResourceNotFoundException() {
+        String accessToken = "dummyAccessToken";
+        JobPostPostRequest request = getDummyJobPostPostRequest();
+
+        // Dummy request and response body for FeignClientException
+        Request fakeFeignRequest = Request.create(
+                Request.HttpMethod.GET,
+                "/addresses/999",
+                new HashMap<>(),
+                null,
+                new RequestTemplate()
+        );
+
+        byte[] errorBody = "{\"message\":\"Address Not Found\"}".getBytes();
+
+        FeignException.FeignClientException notFoundException = new FeignException.FeignClientException(
+                HttpStatus.NOT_FOUND.value(),
+                "Address Not Found",
+                fakeFeignRequest,
+                errorBody,
+                null
+        );
+
+        when(userServiceClient.getAddressById(accessToken, request.getAddressId()))
+                .thenThrow(notFoundException);
+
+        // Act & Assert
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
+                () -> jobPostImpl.createJobPost(accessToken, request));
+
+        assertTrue(exception.getMessage().contains("Address Not Found"));
+    }
+
+    // Test Methods for updateJobPost
+    //==================================================================================================================
+    /**
+     * Testing for a successful update of a job post.
+     * <p>
+     * Given a valid job post exists in the repository,
+     * when updateJobPost is called then the job post is updated successfully.
+     * </p>
+     */
+    @Test
+    void updateJobPost_AsJobPoster_Success() throws Exception {
+        // Arrange
+        String accessToken = "token";
+        UUID jobPosterId = UUID.randomUUID();
+        Long jobPostId = 1L;
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(jobPosterId)
+                .status(JobStatus.OPEN)
+                .build();
+
+        JobPostPatchRequest patchRequest = new JobPostPatchRequest();
+        patchRequest.setTitle("Updated Title");
+        patchRequest.setDescription("Updated Description");
+        patchRequest.setMaxApplicants(10);
+        patchRequest.setTags(Set.of(JobTagEnum.OTHER));
+
+        try (MockedStatic<JWTUtils> jwtStatic = mockStatic(JWTUtils.class)) {
+            jwtStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(jobPosterId);
+            when(jwtUtils.hasAdminRole(accessToken)).thenReturn(false);
+            when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+            // Act
+            jobPostImpl.updateJobPost(accessToken, jobPostId, patchRequest);
+
+            // Assert
+            assertEquals("Updated Title", jobPost.getTitle());
+            assertEquals("Updated Description", jobPost.getDescription());
+            assertEquals(10, jobPost.getMaxApplicants());
+            assertEquals(1, jobPost.getTags().size());
+
+            verify(jobPostRepository).save(jobPost);
+        }
+    }
+
+    /**
+     * Testing for an invalid request scenario.
+     * <p>
+     * Given a job post is not found in the repository,
+     * when updateJobPost is called then a ResourceNotFoundException is thrown.
+     * </p>
+     */
+    @Test
+    void updateJobPost_NotOpenStatus_ThrowsForbiddenException() throws Exception {
+        String accessToken = "token";
+        UUID jobPosterId = UUID.randomUUID();
+        Long jobPostId = 1L;
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(jobPosterId)
+                .status(JobStatus.COMPLETED)
+                .build();
+
+        JobPostPatchRequest patchRequest = new JobPostPatchRequest();
+
+        try (MockedStatic<JWTUtils> jwtStatic = mockStatic(JWTUtils.class)) {
+            jwtStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(jobPosterId);
+            when(jwtUtils.hasAdminRole(accessToken)).thenReturn(false);
+            when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+            // Act & Assert
+            assertThrows(ForbiddenException.class,
+                    () -> jobPostImpl.updateJobPost(accessToken, jobPostId, patchRequest));
+        }
+    }
+
+    @Test
+    void updateJobPost_AsAdmin_CanUpdateNonOpenStatus() throws Exception {
+        Long jobPostId = 1L;
+        UUID jobPosterId = UUID.randomUUID();
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(jobPosterId)
+                .status(JobStatus.IN_PROGRESS)
+                .build();
+
+        JobPostPatchRequest patchRequest = new JobPostPatchRequest();
+        patchRequest.setTitle("Updated title");
+
+        String accessToken = "";
+        when(jwtUtils.hasAdminRole(accessToken)).thenReturn(true); // stub admin
+
+        try (MockedStatic<JWTUtils> jwtStatic = mockStatic(JWTUtils.class)) {
+            jwtStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(jobPosterId); //  stub static call
+
+            when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+            // Run
+            jobPostImpl.updateJobPost(accessToken, jobPostId, patchRequest);
+
+            // Verify
+            assertEquals("Updated title", jobPost.getTitle());
+            verify(jobPostRepository).save(jobPost);
+        }
+    }
+
+    // Test Methods for deleteJobPost
+    //==================================================================================================================
+    /**
+     * Testing for an invalid request scenario.
+     * <p>
+     * Given a job post is not found in the repository,
+     * when updateJobPost is called then a ResourceNotFoundException is thrown.
+     * </p>
+     */
+    @Test
+    void deleteJobPost_AsAdmin_DeletesSuccessfully() throws Exception {
+        Long jobPostId = 1L;
+        String accessToken = "valid-admin-token";
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .status(JobStatus.OPEN)
+                .build();
+
+        // Stub JWT role check
+        when(jwtUtils.hasAdminRole(accessToken)).thenReturn(true);
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+        // Act
+        jobPostImpl.deleteJobPost(accessToken, jobPostId);
+
+        // Assert
+        verify(jobPostRepository).delete(jobPost);
+    }
+
+    /**
+     * Testing for a successful deletion of a job post by the job poster.
+     * <p>
+     * Given a valid job post exists in the repository,
+     * when deleteJobPost is called then the job post is deleted successfully.
+     * </p>
+     */
+    @Test
+    void deleteJobPost_JobPostNotFound_ThrowsNotFound() {
+        Long jobPostId = 999L;
+        String accessToken = "admin-token";
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> jobPostImpl.deleteJobPost(accessToken, jobPostId));
+    }
+
+    // Test Methods for applyJobPost
+    //==================================================================================================================
+    /**
+     * Testing for a successful application to a job post.
+     * <p>
+     * Given a valid job post exists in the repository,
+     * when applyJobPost is called then the application is created successfully.
+     * </p>
+     */
+    @Test
+    void applyToJobPost_Success() {
+        // Arrange
+        JobPost jobPost = getDummyJobPost(); // Status OPEN
+        UUID userId = UUID.randomUUID();
+        JobPostApplyRequest applyRequest = new JobPostApplyRequest("Excited to apply!");
+
+        when(jobPostRepository.findById(1L)).thenReturn(Optional.of(jobPost));
+
+        // Act
+        jobPostImpl.applyToJobPost(userId, 1L, applyRequest);
+
+        // Assert
+        assertEquals(1, jobPost.getApplicants().size());
+
+        Applicant savedApplicant = jobPost.getApplicants().iterator().next();
+        assertEquals(userId, savedApplicant.getUserId());
+        assertEquals("Excited to apply!", savedApplicant.getMessage());
+        assertEquals(ApplicantStatus.PENDING, savedApplicant.getStatus());
+
+        verify(applicantRepository).save(any(Applicant.class));
+        verify(jobPostRepository).save(jobPost);
+        verify(notificationService, times(2)).sendNotification(any(), eq(KafkaTopic.APPLICANT_APPLIED));
+
+    }
+
+    /**
+     * Testing for a successful application to a job post when the job post is not open.
+     * <p>
+     * Given a valid job post exists in the repository but is not open,
+     * when applyJobPost is called then a ForbiddenException is thrown.
+     * </p>
+     */
+    @Test
+    void applyToJobPost_NotOpenStatus_ShouldThrowForbiddenException() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        JobPost jobPost = getDummyJobPost();
+        jobPost.setStatus(JobStatus.COMPLETED); // Not OPEN
+
+        when(jobPostRepository.findById(1L)).thenReturn(Optional.of(jobPost));
+
+        // Act & Assert
+        ForbiddenException exception = assertThrows(ForbiddenException.class,
+                () -> jobPostImpl.applyToJobPost(userId, 1L, new JobPostApplyRequest("Applying to closed job")));
+
+        assertTrue(exception.getMessage().contains("JobStatus does not allow for this action"));
+
+        verify(applicantRepository, never()).save(any());
+        verify(jobPostRepository, never()).save(any());
+    }
+
+    /**
+     * Testing for a successful application to a job post when the user is already an applicant.
+     * <p>
+     * Given a valid job post exists in the repository and the user is already an applicant,
+     * when applyJobPost is called then an InvalidRequestException is thrown.
+     * </p>
+     */
+    @Test
+    void applyToJobPost_AlreadyApplied_ShouldThrowForbiddenException() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        JobPost jobPost = getDummyJobPost();
+        jobPost.getApplicants().add(Applicant.builder()
+                .userId(userId)
+                .status(ApplicantStatus.PENDING)
+                .build());
+
+        when(jobPostRepository.findById(1L)).thenReturn(Optional.of(jobPost));
+
+        // Act & Assert
+        ForbiddenException exception = assertThrows(ForbiddenException.class,
+                () -> jobPostImpl.applyToJobPost(userId, 1L, new JobPostApplyRequest("Applying again")));
+
+        assertTrue(exception.getMessage().contains("already applied"));
+
+        verify(applicantRepository, never()).save(any());
+        verify(jobPostRepository, never()).save(any());
+    }
+
+    // Test Methods for takeActionOnApplication
+    //==================================================================================================================
+    /**
+     * Testing for a successful action on an applicant.
+     * <p>
+     * Given a valid job post and applicant exist in the repository,
+     * when takeApplicantsAction is called then the applicant's status is updated successfully.
+     * </p>
+     */
+    @Test
+    void takeApplicantsAction_Success() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        Long jobPostId = 1L;
+        Long applicantId = 100L;
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(userId)
+                .status(JobStatus.OPEN)
+                .maxApplicants(1)
+                .applicants(new HashSet<>())
+                .build();
+
+        Applicant applicant = Applicant.builder()
+                .applicantId(applicantId)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.PENDING)
+                .build();
+
+        jobPost.getApplicants().add(applicant);
+
+        ApplicantActionRequest actionRequest = ApplicantActionRequest.builder()
+                .applicantId(applicant.getApplicantId().intValue()) // <-- intValue() here
+                .status(ApplicantStatus.ACCEPTED)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+        // Act
+        jobPostImpl.takeApplicantsAction(userId, jobPostId, List.of(actionRequest));
+
+        // Assert
+        assertEquals(ApplicantStatus.ACCEPTED, applicant.getStatus());
+        assertEquals(JobStatus.IN_PROGRESS, jobPost.getStatus());
+
+        verify(applicantRepository).saveAll(any());
+        verify(jobPostRepository).save(jobPost);
+
+        verify(notificationService).sendNotification(any(), eq(KafkaTopic.JOB_POST_START));
+        verify(notificationService).sendNotification(any(), eq(KafkaTopic.APPLICANT_CONFIRMED));
+    }
+
+    /**
+     * Testing for a successful action on an applicant when the job post is not open.
+     * <p>
+     * Given a valid job post and applicant exist in the repository but the job post is not open,
+     * when takeApplicantsAction is called then a ForbiddenException is thrown.
+     * </p>
+     */
+    @Test
+    void takeApplicantsAction_InvalidApplicant_ThrowsResourceNotFoundException() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        Long jobPostId = 1L;
+
+        // Create a dummy JobPost with 1 applicant (ID = 100L)
+        Applicant applicant = Applicant.builder()
+                .applicantId(100L)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.PENDING)
+                .build();
+
+        Set<Applicant> applicants = new HashSet<>();
+        applicants.add(applicant);
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(userId)
+                .maxApplicants(5)
+                .status(JobStatus.OPEN)
+                .applicants(applicants)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+        // Act
+        List<ApplicantActionRequest> actionRequests = List.of(
+                new ApplicantActionRequest(999, ApplicantStatus.ACCEPTED) // Invalid applicantId
+        );
+
+        // Assert
+        assertThrows(ResourceNotFoundException.class, () ->
+                jobPostImpl.takeApplicantsAction(userId, jobPostId, actionRequests)
+        );
+
+        verify(jobPostRepository).findById(jobPostId);
+    }
+
+    /**
+     * Testing for a successful action on an applicant when the job post has too many accepted applicants.
+     * <p>
+     * Given a valid job post and applicant exist in the repository but the job post has too many accepted applicants,
+     * when takeApplicantsAction is called then a ForbiddenException is thrown.
+     * </p>
+     */
+    @Test
+    void takeApplicantsAction_TooManyAcceptedApplicants_ThrowsForbiddenException() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        Long jobPostId = 1L;
+
+        // JobPost with maxApplicants = 1
+        Applicant acceptedApplicant = Applicant.builder()
+                .applicantId(100L)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.ACCEPTED)
+                .build();
+
+        Applicant newApplicant = Applicant.builder()
+                .applicantId(101L)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.PENDING)
+                .build();
+
+        Set<Applicant> applicants = new HashSet<>(Set.of(acceptedApplicant, newApplicant));
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(userId)
+                .maxApplicants(1) // Already filled
+                .status(JobStatus.OPEN)
+                .applicants(applicants)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+        // Act
+        List<ApplicantActionRequest> actionRequests = List.of(
+                new ApplicantActionRequest(101, ApplicantStatus.ACCEPTED) // Trying to accept one more
+        );
+
+        // Assert
+        assertThrows(ForbiddenException.class, () ->
+                jobPostImpl.takeApplicantsAction(userId, jobPostId, actionRequests)
+        );
+
+        verify(jobPostRepository).findById(jobPostId);
+    }
+
+    /**
+     * Testing for a successful action on an applicant when the job post is not open.
+     * <p>
+     * Given a valid job post and applicant exist in the repository but the job post is not open,
+     * when takeApplicantsAction is called then a hrowsInvalidRequestException is thrown.
+     * </p>
+     */
+    @Test
+    void takeApplicantsAction_InvalidStatus_ThrowsInvalidRequestException() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        Long jobPostId = 1L;
+
+        Applicant applicant = Applicant.builder()
+                .applicantId(100L)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.PENDING)
+                .build();
+
+        Set<Applicant> applicants = new HashSet<>();
+        applicants.add(applicant);
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(userId)
+                .maxApplicants(5)
+                .status(JobStatus.OPEN)
+                .applicants(applicants)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+        // Act
+        // Here, we pass a status that your business logic considers invalid.
+        List<ApplicantActionRequest> actionRequests = List.of(
+                new ApplicantActionRequest(100, null) // null = invalid
+        );
+
+        // Assert
+        assertThrows(InvalidRequestException.class, () ->
+                jobPostImpl.takeApplicantsAction(userId, jobPostId, actionRequests)
+        );
+
+        verify(jobPostRepository).findById(jobPostId);
+    }
+    // Test Methods for UpadateApplicant message
+    //==================================================================================================================
+    /**
+     * Testing for a successful update of an applicant's message.
+     * <p>
+     * Given a valid job post and applicant exist in the repository,
+     * when updateApplicantStatus is called then the applicant's message is updated successfully.
+     * </p>
+     */
+    @Test
+    void updateApplicantMessage_Success() throws Exception {
+        // Arrange
+        String accessToken = "dummyAccessToken";
+        Long jobPostId = 1L;
+        Long applicantId = 100L;
+        String newMessage = "Updated message";
+
+        UUID applicantUserId = UUID.randomUUID();
+
+        Applicant applicant = Applicant.builder()
+                .applicantId(applicantId)
+                .userId(applicantUserId)
+                .status(ApplicantStatus.PENDING)
+                .message("Old message")
+                .build();
+
+        Set<Applicant> applicants = new HashSet<>(Set.of(applicant));
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(UUID.randomUUID())
+                .maxApplicants(5)
+                .status(JobStatus.OPEN)
+                .applicants(applicants)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+        when(jwtUtils.hasAdminRole(accessToken)).thenReturn(true); // Make user admin to skip applicant check
+
+        // Act
+        jobPostImpl.updateApplicantMessage(accessToken, jobPostId, applicantId, newMessage);
+
+        // Assert
+        assertEquals(newMessage, applicant.getMessage());
+
+        verify(applicantRepository).save(applicant);
+        verify(jobPostRepository).findById(jobPostId);
+    }
+
+    //Delete Applicant
+    //==================================================================================================================
+    /**
+     * Testing for a successful deletion of an applicant.
+     * <p>
+     * Given a valid job post and applicant exist in the repository,
+     * when deleteApplicant is called then the applicant is deleted successfully.
+     * </p>
+     */
+    @Test
+    void deleteApplicant_Success() throws Exception {
+        // Arrange
+        String accessToken = "dummyAccessToken";
+        Long jobPostId = 1L;
+        Long applicantId = 100L;
+
+        Applicant applicant = Applicant.builder()
+                .applicantId(applicantId)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.PENDING)
+                .build();
+
+        Set<Applicant> applicants = new HashSet<>(Set.of(applicant));
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .status(JobStatus.OPEN)
+                .applicants(applicants)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+        when(jwtUtils.hasAdminRole(accessToken)).thenReturn(true);
+
+        // Act
+        jobPostImpl.deleteApplicant(accessToken, jobPostId, applicantId);
+
+        // Assert
+        assertTrue(jobPost.getApplicants().isEmpty(), "Applicant should be removed");
+        verify(jobPostRepository).save(jobPost);
+        verify(jobPostRepository).findById(jobPostId);
+    }
+
+    /**
+     * Testing for a successful deletion of an applicant when the job post is not open.
+     * <p>
+     * Given a valid job post and applicant exist in the repository but the job post is not open,
+     * when deleteApplicant is called then a nvalidApplicant_ThrowsResourceNotFoundException( is thrown.
+     * </p>
+     */
+    //Applicant Not Found
+    @Test
+    void deleteApplicant_InvalidApplicant_ThrowsResourceNotFoundException() throws Exception {
+        // Arrange
+        String accessToken = "dummyAccessToken";
+        Long jobPostId = 1L;
+        Long invalidApplicantId = 999L;
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .status(JobStatus.OPEN)
+                .applicants(new HashSet<>()) // No applicants
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+        when(jwtUtils.hasAdminRole(accessToken)).thenReturn(true);
+
+        // Act & Assert
+        assertThrows(ResourceNotFoundException.class, () ->
+                jobPostImpl.deleteApplicant(accessToken, jobPostId, invalidApplicantId));
+
+        verify(jobPostRepository).findById(jobPostId);
+    }
+
+    /**
+     * Testing for a successful deletion of an applicant when the job post is not open.
+     * <p>
+     * Given a valid job post and applicant exist in the repository but the job post is not open,
+     * when deleteApplicant is called then a ForbiddenException is thrown.
+     * </p>
+     */
+    @Test
+    void deleteApplicant_JobNotOpen_ThrowsForbiddenException() throws Exception {
+        // Arrange
+        String accessToken = "dummyAccessToken";
+        Long jobPostId = 1L;
+        Long applicantId = 100L;
+
+        Applicant applicant = Applicant.builder()
+                .applicantId(applicantId)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.PENDING)
+                .build();
+
+        Set<Applicant> applicants = new HashSet<>(Set.of(applicant));
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .status(JobStatus.COMPLETED) // NOT OPEN
+                .applicants(applicants)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+        when(jwtUtils.hasAdminRole(accessToken)).thenReturn(true);
+
+        // Act & Assert
+        assertThrows(ForbiddenException.class, () ->
+                jobPostImpl.deleteApplicant(accessToken, jobPostId, applicantId));
+
+        verify(jobPostRepository).findById(jobPostId);
+    }
+
+    // Test Methods for startJobPost
+    //==================================================================================================================
+    /**
+     * Testing for a successful start of a job post.
+     * <p>
+     * Given a valid job post exists in the repository,
+     * when startJobPost is called then the job post is started successfully.
+     * </p>
+     */
+    @Test
+    void startJobPost_Success() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        Long jobPostId = 1L;
+
+        Applicant acceptedApplicant = Applicant.builder()
+                .applicantId(100L)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.ACCEPTED)
+                .build();
+
+        Applicant pendingApplicant = Applicant.builder()
+                .applicantId(101L)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.PENDING)
+                .build();
+
+        Set<Applicant> applicants = new HashSet<>(Set.of(acceptedApplicant, pendingApplicant));
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(userId)
+                .status(JobStatus.OPEN)
+                .applicants(applicants)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+        // Act
+        jobPostImpl.startJobPost(userId, jobPostId);
+
+        // Assert
+        assertEquals(JobStatus.IN_PROGRESS, jobPost.getStatus(), "Job post should be IN_PROGRESS");
+        assertTrue(jobPost.getApplicants().stream()
+                .noneMatch(applicant -> applicant.getStatus() == ApplicantStatus.PENDING), "All PENDING applicants must be REJECTED");
+
+        verify(applicantRepository).saveAll(applicants);
+        verify(jobPostRepository).save(jobPost);
+    }
+
+    //no accepted applicants
+    /**
+     * Testing for a successful start of a job post when there are no accepted applicants.
+     * <p>
+     * Given a valid job post exists in the repository but has no accepted applicants,
+     * when startJobPost is called then an InvalidRequestException is thrown.
+     * </p>
+     */
+    @Test
+    void startJobPost_NoAcceptedApplicants_ThrowsInvalidRequestException() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        Long jobPostId = 1L;
+
+        Applicant pendingApplicant = Applicant.builder()
+                .applicantId(100L)
+                .userId(UUID.randomUUID())
+                .status(ApplicantStatus.PENDING)
+                .build();
+
+        Set<Applicant> applicants = new HashSet<>(Set.of(pendingApplicant));
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(userId)
+                .status(JobStatus.OPEN)
+                .applicants(applicants)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+
+        // Act & Assert
+        InvalidRequestException exception = assertThrows(InvalidRequestException.class,
+                () -> jobPostImpl.startJobPost(userId, jobPostId));
+        assertTrue(exception.getMessage().contains("At least 1 applicant must be accepted"));
+
+        verify(jobPostRepository).findById(jobPostId);
+    }
+//Canncel Job Post
+    //===================================================================================================================
+    /**
+     * Testing for a successful cancellation of a job post.
+     * <p>
+     * Given a valid job post exists in the repository,
+     * when cancelJobPost is called then the job post is cancelled successfully.
+     * </p>
+     */
+    @Test
+    void cancelJobPost_Success_AsPosterOrAdmin() throws Exception {
+        // Arrange
+        String accessToken = "dummyToken";
+        UUID jobPosterId = UUID.randomUUID();
+        Long jobPostId = 1L;
+
+        Set<Applicant> applicants = new HashSet<>(Set.of(
+                Applicant.builder().applicantId(100L).status(ApplicantStatus.PENDING).build(),
+                Applicant.builder().applicantId(101L).status(ApplicantStatus.ACCEPTED).build()
+        ));
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(jobPosterId)
+                .status(JobStatus.OPEN)
+                .applicants(applicants)
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+        try (MockedStatic<JWTUtils> jwtUtilsMockedStatic = Mockito.mockStatic(JWTUtils.class)) {
+            jwtUtilsMockedStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(jobPosterId);
+            when(jwtUtils.hasAdminRole(accessToken)).thenReturn(false);
+
+            // Act
+            jobPostImpl.cancelJobPost(accessToken, jobPostId);
+
+            // Assert
+            assertEquals(JobStatus.CANCELLED, jobPost.getStatus(), "JobPost status should be CANCELLED");
+            assertTrue(jobPost.getApplicants().stream().allMatch(a -> a.getStatus() == ApplicantStatus.REJECTED),
+                    "All applicants should be REJECTED");
+
+            verify(applicantRepository).saveAll(applicants);
+            verify(jobPostRepository).save(jobPost);
+        }
+    }
+
+    // Test for forbidden exception when job post is in progress or completed
+    /**
+     * Testing for a successful cancellation of a job post when the job post is complete or in progress.
+     * <p>
+     * Given a valid job post exists in the repository but is not open,
+     * when cancelJobPost is called then a ForbiddenException is thrown.
+     * </p>
+     */
+    @Test
+    void cancelJobPost_JobNotOpen_ThrowsForbiddenException() throws Exception {
+        // Arrange
+        String accessToken = "dummyToken";
+        UUID jobPosterId = UUID.randomUUID();
+        Long jobPostId = 1L;
+
+        JobPost jobPost = JobPost.builder()
+                .jobPostId(jobPostId)
+                .jobPosterId(jobPosterId)
+                .status(JobStatus.IN_PROGRESS) // Not OPEN
+                .applicants(new HashSet<>())
+                .build();
+
+        when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+        try (MockedStatic<JWTUtils> jwtUtilsMockedStatic = Mockito.mockStatic(JWTUtils.class)) {
+            jwtUtilsMockedStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(jobPosterId);
+            when(jwtUtils.hasAdminRole(accessToken)).thenReturn(false);
+
+            // Act & Assert
+            ForbiddenException exception = assertThrows(ForbiddenException.class,
+                    () -> jobPostImpl.cancelJobPost(accessToken, jobPostId));
+            assertTrue(exception.getMessage().contains("JobStatus does not allow"));
+        }
+
+        verify(jobPostRepository).findById(jobPostId);
+    }
+
+    //
+    //
     //==================================================================================================================
     //                                               Helper Methods
     //==================================================================================================================
@@ -366,7 +1391,36 @@ public class JobPostServiceImplTests {
         );
     }
 
+    /**
+     * Provides test parameters for the searchMyJobPosts_success test.
+     *
+     * @return a stream of arguments for the test.
+     */
 
+    static Stream<Arguments> searchMyJobPostsTestParameters() {
+        return Stream.of(
+                Arguments.of(1, "All Parameters", "Test", "OTHER", "OPEN", 0, 5),
+                Arguments.of(2, "Empty Title", "", "OTHER", "OPEN", 0, 5),
+                Arguments.of(3, "Empty Tag", "Test", "", "OPEN", 0, 5),
+                Arguments.of(4, "Empty Status", "Test", "OTHER", "", 0, 5),
+                Arguments.of(5, "All Empty Filters", "", "", "", 0, 5),
+                Arguments.of(6, "Null Filters", null, null, null, 0, 5)
+        );
+    }
+
+    /**
+     * Provides test parameters for the searchJobsUserWorkedOn_success test.
+     *
+     * @return a stream of arguments for the test.
+     */
+    static Stream<Arguments> searchJobsUserWorkedOnTestParameters() {
+        return Stream.of(
+                Arguments.of(1, "All filters", "Test", "OPEN", "title", "asc", 0, 5),
+                Arguments.of(2, "No filters", null, null, "datePosted", "desc", 0, 5),
+                Arguments.of(3, "Only sort", null, null, "status", "asc", 0, 5),
+                Arguments.of(4, "Only title", "Example", null, "datePosted", "asc", 0, 5)
+        );
+    }
 
 
     //Toggler Method for Admin and Job Poster Test
@@ -464,4 +1518,62 @@ public class JobPostServiceImplTests {
 
     }
 
+    /**
+     * Creates a page of job posts with an applicant for testing purposes
+     * The Number of job posts assigned to a page can be changed
+     *
+     * @return a dummy job post with an applicant
+     */
+    private Page<JobPost> getDummyJobPostsPageWithApplicant(int numberOfJobPosts, UUID userId) {
+        List<JobPost> posts = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
+
+        for (int i = 0; i < numberOfJobPosts; i++) {
+            Applicant applicant = Applicant.builder()
+                    .applicantId((long) (100 + i))
+                    .userId(userId)
+                    .status(ApplicantStatus.PENDING)
+                    .dateApplied(now.minusDays(i))
+                    .dateUpdated(now.minusHours(i))
+                    .build();
+
+            JobPost jobPost = getDummyJobPost();
+            jobPost.setJobPostId((long) i);
+            jobPost.setApplicants(Set.of(applicant));
+            posts.add(jobPost);
+        }
+
+        return new PageImpl<>(posts);
+    }
+
+    /**
+     * Creates a dummy address response for testing purposes
+     *
+     * @return a dummy address response
+     */
+    private AddressResponse getDummyAddressResponse() {
+        return AddressResponse.builder()
+                .address("123 Main St")
+                .longitude(10.0)
+                .latitude(20.0)
+                .build();
+    }
+
+    /**
+     * Creates a dummy job post request for testing purposes
+     *
+     * @return a dummy job post request
+     */
+
+    private JobPostPostRequest getDummyJobPostPostRequest() {
+        return JobPostPostRequest.builder()
+                .title("New Job Post")
+                .description("Looking for a skilled worker")
+                .tags(Set.of(JobTagEnum.OTHER)) // assuming JobTagEnum exists
+                .addressId(123L)
+                .maxApplicants(3)
+                .build();
+    }
+
 }
+


### PR DESCRIPTION
This pull request includes significant changes to the `JobPostController` and `JobPostService` classes to improve the handling of user authentication and simplify the method signatures. Additionally, it introduces the `@Builder` annotation to several DTO classes.

Improvements to user authentication handling:

* [`jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/controller/JobPostController.java`](diffhunk://#diff-9b17109abcdd991cadfb41f5a98599ffd64fc0efd130a8acd2ae70c3ccb49a7bL201-R202): Updated methods to pass `accessToken` directly to the service layer instead of extracting `userId` in the controller. [[1]](diffhunk://#diff-9b17109abcdd991cadfb41f5a98599ffd64fc0efd130a8acd2ae70c3ccb49a7bL201-R202) [[2]](diffhunk://#diff-9b17109abcdd991cadfb41f5a98599ffd64fc0efd130a8acd2ae70c3ccb49a7bL225-R224)
* [`jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java`](diffhunk://#diff-aa29ed822bfccf387fb05bfa816af190970dc83513dbad4112d7294602d402e9L213-R221): Modified methods to extract `userId` from `accessToken` within the service methods, ensuring consistent user authentication. [[1]](diffhunk://#diff-aa29ed822bfccf387fb05bfa816af190970dc83513dbad4112d7294602d402e9L213-R221) [[2]](diffhunk://#diff-aa29ed822bfccf387fb05bfa816af190970dc83513dbad4112d7294602d402e9L251-R260)

Simplification of method signatures:

* [`jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/JobPostService.java`](diffhunk://#diff-0869c94be57dd4eed45881798d0ec66141e4d66020565677f13b1e56073ccd15L24-R24): Changed method signatures to use `accessToken` instead of `userId` and removed return types from methods where they were not necessary. [[1]](diffhunk://#diff-0869c94be57dd4eed45881798d0ec66141e4d66020565677f13b1e56073ccd15L24-R24) [[2]](diffhunk://#diff-0869c94be57dd4eed45881798d0ec66141e4d66020565677f13b1e56073ccd15L35-R45)
* [`jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/service/Implementation/JobPostImpl.java`](diffhunk://#diff-aa29ed822bfccf387fb05bfa816af190970dc83513dbad4112d7294602d402e9L509-R525): Updated corresponding implementations to match the new signatures and removed unnecessary return statements. [[1]](diffhunk://#diff-aa29ed822bfccf387fb05bfa816af190970dc83513dbad4112d7294602d402e9L509-R525) [[2]](diffhunk://#diff-aa29ed822bfccf387fb05bfa816af190970dc83513dbad4112d7294602d402e9L745-R757)

Introduction of `@Builder` annotation:

* [`jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/AddressResponse.java`](diffhunk://#diff-d0cfef8368ee2ce6c7c3b86a355b72ba031319a5b8a2fe7ca7e27b3be882ce3fR4-R11): Added `@Builder` annotation to the `AddressResponse` class.
* [`jobspotter_backend/services/job-post/src/main/java/org/job_spotter/jobpost/dto/JobPostPostRequest.java`](diffhunk://#diff-0160269ca8f1b5ee58789703da0481f1642ed39fa5a7490d88a8af004e651f7dR10): Added `@Builder` annotation to the `JobPostPostRequest` class. [[1]](diffhunk://#diff-0160269ca8f1b5ee58789703da0481f1642ed39fa5a7490d88a8af004e651f7dR10) [[2]](diffhunk://#diff-0160269ca8f1b5ee58789703da0481f1642ed39fa5a7490d88a8af004e651f7dR20)