### PR TITLE
feat: Add Dockerfile for multiple services with build and runtime stages

### DIFF
--- a/jobspotter_backend/services/config-server/Dockerfile
+++ b/jobspotter_backend/services/config-server/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM maven:3.9.9-amazoncorretto-21 AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+
+# Runtime stage
+FROM amazoncorretto:21
+ARG PROFILE=docker
+
+ENV ACTIVE_PROFILE=${PROFILE}
+
+WORKDIR /app
+COPY --from=build /build/target/config-server-*.jar /app/
+
+EXPOSE 8888
+
+CMD java -jar -Dspring.profiles.active=${ACTIVE_PROFILE}  config-server-*.jar

--- a/jobspotter_backend/services/discovery/Dockerfile
+++ b/jobspotter_backend/services/discovery/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM maven:3.9.9-amazoncorretto-21 AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+
+# Runtime stage
+FROM amazoncorretto:21
+ARG PROFILE=docker
+
+ENV ACTIVE_PROFILE=${PROFILE}
+
+WORKDIR /app
+COPY --from=build /build/target/discovery-service-*.jar /app/
+
+EXPOSE 8761
+
+CMD java -jar -Dspring.profiles.active=${ACTIVE_PROFILE}  discovery-service-*.jar

--- a/jobspotter_backend/services/gateway/Dockerfile
+++ b/jobspotter_backend/services/gateway/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM maven:3.9.9-amazoncorretto-21 AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+
+# Runtime stage
+FROM amazoncorretto:21
+ARG PROFILE=docker
+
+ENV ACTIVE_PROFILE=${PROFILE}
+
+WORKDIR /app
+COPY --from=build /build/target/gateway-service-*.jar /app/
+
+EXPOSE 8100
+
+CMD java -jar -Dspring.profiles.active=${ACTIVE_PROFILE}  gateway-service-*.jar

--- a/jobspotter_backend/services/job-post/Dockerfile
+++ b/jobspotter_backend/services/job-post/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM maven:3.9.9-amazoncorretto-21 AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+
+# Runtime stage
+FROM amazoncorretto:21
+ARG PROFILE=docker
+
+ENV ACTIVE_PROFILE=${PROFILE}
+
+WORKDIR /app
+COPY --from=build /build/target/job-post-service-*.jar /app/
+
+EXPOSE 8081
+
+CMD java -jar -Dspring.profiles.active=${ACTIVE_PROFILE}  job-post-service-*.jar

--- a/jobspotter_backend/services/notification/Dockerfile
+++ b/jobspotter_backend/services/notification/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM maven:3.9.9-amazoncorretto-21 AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+
+# Runtime stage
+FROM amazoncorretto:21
+ARG PROFILE=docker
+
+ENV ACTIVE_PROFILE=${PROFILE}
+
+WORKDIR /app
+COPY --from=build /build/target/notification-service-*.jar /app/
+
+EXPOSE 8083
+
+CMD java -jar -Dspring.profiles.active=${ACTIVE_PROFILE}  notification-service-*.jar

--- a/jobspotter_backend/services/report/Dockerfile
+++ b/jobspotter_backend/services/report/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM maven:3.9.9-amazoncorretto-21 AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+
+# Runtime stage
+FROM amazoncorretto:21
+ARG PROFILE=docker
+
+ENV ACTIVE_PROFILE=${PROFILE}
+
+WORKDIR /app
+COPY --from=build /build/target/report-service-*.jar /app/
+
+EXPOSE 8084
+
+CMD java -jar -Dspring.profiles.active=${ACTIVE_PROFILE}  report-service-*.jar

--- a/jobspotter_backend/services/review/Dockerfile
+++ b/jobspotter_backend/services/review/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM maven:3.9.9-amazoncorretto-21 AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+
+# Runtime stage
+FROM amazoncorretto:21
+ARG PROFILE=docker
+
+ENV ACTIVE_PROFILE=${PROFILE}
+
+WORKDIR /app
+COPY --from=build /build/target/user-service-*.jar /app/
+
+EXPOSE 8080
+
+CMD java -jar -Dspring.profiles.active=${ACTIVE_PROFILE}  user-service-*.jar

--- a/jobspotter_backend/services/user/Dockerfile
+++ b/jobspotter_backend/services/user/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM maven:3.9.9-amazoncorretto-21 AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+
+# Runtime stage
+FROM amazoncorretto:21
+ARG PROFILE=docker
+
+ENV ACTIVE_PROFILE=${PROFILE}
+
+WORKDIR /app
+COPY --from=build /build/target/review-service-*.jar /app/
+
+EXPOSE 8082
+
+CMD java -jar -Dspring.profiles.active=${ACTIVE_PROFILE}  review-service-*.jar


### PR DESCRIPTION
This pull request introduces Dockerfiles for multiple services in the `jobspotter_backend` project, standardizing their build and runtime configurations. Each Dockerfile uses a multi-stage build process with Maven for dependency management and Amazon Corretto as the runtime environment. The most important changes are summarized below:

### Standardized Multi-Stage Build Process:
* Added a build stage using the `maven:3.9.9-amazoncorretto-21` image to compile the services, with offline dependency resolution (`mvn dependency:go-offline`) and skipping tests during packaging (`mvn clean package -DskipTests`). (`[[1]](diffhunk://#diff-f7d6102f1084f1b29c805aa58c7f34d667343ca4aedf66dc54ea069baac43754R1-R21)`, `[[2]](diffhunk://#diff-e5c87304d3c8ce19140b0b5a276ad2ad807482b01b18df18a7118548f2e0f617R1-R21)`, `[[3]](diffhunk://#diff-1eff1af64763a82eada4daae106b72a75353dc7ff55021dfe704e6c23b40d666R1-R21)`, `[[4]](diffhunk://#diff-dc34de3e2f185df77b8039cc9bcdcb380f4e63f7988fb68f214adb63e1a356d4R1-R21)`, `[[5]](diffhunk://#diff-803be564e32553d7178f66f84c93bfe841976e08de308d4f860bc527935bf74eR1-R21)`, `[[6]](diffhunk://#diff-2db1b62da44b09ee81e9f5f496a2167ca7988c02f817ba05645f8d08617c7958R1-R21)`, `[[7]](diffhunk://#diff-489c42a045435feb4b112013e24cadf3d522f0bbe414d14b9ed5158c5eeabb70R1-R21)`, `[[8]](diffhunk://#diff-bca690cfc95886561b2704e69a197eb10a0786fedc4a8304a25090dc00239b10R1-R21)`)

### Runtime Configuration:
* Added a runtime stage using the `amazoncorretto:21` image, with support for dynamic profile configuration via the `PROFILE` build argument and `ACTIVE_PROFILE` environment variable. (`[[1]](diffhunk://#diff-f7d6102f1084f1b29c805aa58c7f34d667343ca4aedf66dc54ea069baac43754R1-R21)`, `[[2]](diffhunk://#diff-e5c87304d3c8ce19140b0b5a276ad2ad807482b01b18df18a7118548f2e0f617R1-R21)`, `[[3]](diffhunk://#diff-1eff1af64763a82eada4daae106b72a75353dc7ff55021dfe704e6c23b40d666R1-R21)`, `[[4]](diffhunk://#diff-dc34de3e2f185df77b8039cc9bcdcb380f4e63f7988fb68f214adb63e1a356d4R1-R21)`, `[[5]](diffhunk://#diff-803be564e32553d7178f66f84c93bfe841976e08de308d4f860bc527935bf74eR1-R21)`, `[[6]](diffhunk://#diff-2db1b62da44b09ee81e9f5f496a2167ca7988c02f817ba05645f8d08617c7958R1-R21)`, `[[7]](diffhunk://#diff-489c42a045435feb4b112013e24cadf3d522f0bbe414d14b9ed5158c5eeabb70R1-R21)`, `[[8]](diffhunk://#diff-bca690cfc95886561b2704e69a197eb10a0786fedc4a8304a25090dc00239b10R1-R21)`)
* Exposed service-specific ports for communication:
  - `config-server` on port `8888` (`[jobspotter_backend/services/config-server/DockerfileR1-R21](diffhunk://#diff-f7d6102f1084f1b29c805aa58c7f34d667343ca4aedf66dc54ea069baac43754R1-R21)`)
  - `discovery-service` on port `8761` (`[jobspotter_backend/services/discovery/DockerfileR1-R21](diffhunk://#diff-e5c87304d3c8ce19140b0b5a276ad2ad807482b01b18df18a7118548f2e0f617R1-R21)`)
  - `gateway-service` on port `8100` (`[jobspotter_backend/services/gateway/DockerfileR1-R21](diffhunk://#diff-1eff1af64763a82eada4daae106b72a75353dc7ff55021dfe704e6c23b40d666R1-R21)`)
  - `job-post-service` on port `8081` (`[jobspotter_backend/services/job-post/DockerfileR1-R21](diffhunk://#diff-dc34de3e2f185df77b8039cc9bcdcb380f4e63f7988fb68f214adb63e1a356d4R1-R21)`)
  - `notification-service` on port `8083` (`[jobspotter_backend/services/notification/DockerfileR1-R21](diffhunk://#diff-803be564e32553d7178f66f84c93bfe841976e08de308d4f860bc527935bf74eR1-R21)`)
  - `report-service` on port `8084` (`[jobspotter_backend/services/report/DockerfileR1-R21](diffhunk://#diff-2db1b62da44b09ee81e9f5f496a2167ca7988c02f817ba05645f8d08617c7958R1-R21)`)
  - `review-service` on port `8082` (`[jobspotter_backend/services/user/DockerfileR1-R21](diffhunk://#diff-bca690cfc95886561b2704e69a197eb10a0786fedc4a8304a25090dc00239b10R1-R21)`)
  - `user-service` on port `8080` (`[jobspotter_backend/services/review/DockerfileR1-R21](diffhunk://#diff-489c42a045435feb4b112013e24cadf3d522f0bbe414d14b9ed5158c5eeabb70R1-R21)`)

### Command Execution:
* Configured each service to run its respective JAR file with the Spring profile set dynamically using `-Dspring.profiles.active=${ACTIVE_PROFILE}`. (`[[1]](diffhunk://#diff-f7d6102f1084f1b29c805aa58c7f34d667343ca4aedf66dc54ea069baac43754R1-R21)`, `[[2]](diffhunk://#diff-e5c87304d3c8ce19140b0b5a276ad2ad807482b01b18df18a7118548f2e0f617R1-R21)`, `[[3]](diffhunk://#diff-1eff1af64763a82eada4daae106b72a75353dc7ff55021dfe704e6c23b40d666R1-R21)`, `[[4]](diffhunk://#diff-dc34de3e2f185df77b8039cc9bcdcb380f4e63f7988fb68f214adb63e1a356d4R1-R21)`, `[[5]](diffhunk://#diff-803be564e32553d7178f66f84c93bfe841976e08de308d4f860bc527935bf74eR1-R21)`, `[[6]](diffhunk://#diff-2db1b62da44b09ee81e9f5f496a2167ca7988c02f817ba05645f8d08617c7958R1-R21)`, `[[7]](diffhunk://#diff-489c42a045435feb4b112013e24cadf3d522f0bbe414d14b9ed5158c5eeabb70R1-R21)`, `[[8]](diffhunk://#diff-bca690cfc95886561b2704e69a197eb10a0786fedc4a8304a25090dc00239b10R1-R21)`)