### PR TITLE
feat: Add Vercel configuration for API rewrites to direct requests to…

### DIFF
--- a/jobspotter_frontend/src/.vercel.json
+++ b/jobspotter_frontend/src/.vercel.json
@@ -1,0 +1,7 @@
+{  
+    "rewrites": [
+         { "source": "/api/:match*",
+           "destination": "https://api.jobspotter.eu/:match*"
+         } 
+   ]
+}


### PR DESCRIPTION
This pull request introduces a configuration file to handle API request routing in the `jobspotter_frontend` project. The key change is the addition of a rewrite rule to direct API calls to the appropriate backend endpoint.

Routing configuration:

* [`jobspotter_frontend/src/.vercel.json`](diffhunk://#diff-af29faf470c0e12192c5ee5d053449cf9110c4eb89ec29fc78a1f743642bc807R1-R7): Added a rewrite rule to route requests from `/api/:match*` to `https://api.jobspotter.eu/:match*`. This ensures that API calls are forwarded to the correct backend service.… 