### PR TITLE
feat: Move Vercel configuration for API rewrites to the root directory

### DIFF
--- a/jobspotter_frontend/.vercel.json
+++ b/jobspotter_frontend/.vercel.json
@@ -1,0 +1,7 @@
+{  
+  "rewrites": [
+       { "source": "/api/:match*",
+         "destination": "https://api.jobspotter.eu/:match*"
+       } 
+ ]
+}

--- a/jobspotter_frontend/src/.vercel.json
+++ b/jobspotter_frontend/src/.vercel.json
@@ -1,7 +1,0 @@
-{  
-    "rewrites": [
-         { "source": "/api/:match*",
-           "destination": "https://api.jobspotter.eu/:match*"
-         } 
-   ]
-}


### PR DESCRIPTION
This pull request updates the configuration for handling API rewrites in the `jobspotter_frontend` project. The changes involve moving the `.vercel.json` file to a new location and ensuring the rewrite rules remain intact.

Configuration updates:

* Added a new `.vercel.json` file in the root directory of `jobspotter_frontend` to define API rewrite rules, redirecting `/api/:match*` to `https://api.jobspotter.eu/:match*`.
* Removed the previous `.vercel.json` file from the `src` directory, as it is no longer needed in that location.