### PR TITLE
feat: renamed versel.json

### DIFF
--- a/jobspotter_frontend/.vercel.json
+++ b/jobspotter_frontend/.vercel.json
@@ -1,7 +1,0 @@
-{  
-  "rewrites": [
-       { "source": "/api/:match*",
-         "destination": "https://api.jobspotter.eu/:match*"
-       } 
- ]
-}

--- a/jobspotter_frontend/vercel.json
+++ b/jobspotter_frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:match*",
+      "destination": "https://api.jobspotter.eu/:match*"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request includes a change to the Vercel configuration for the `jobspotter_frontend` project. The `.vercel.json` file has been removed, and a new `vercel.json` file has been created with the same rewrite rules.

Configuration changes:

* [`jobspotter_frontend/.vercel.json`](diffhunk://#diff-da8873e927225cffa095ff5a4cd37c5682e59c9d65b33733a35bed95a932721bL1-L7): Removed the file entirely, which previously contained rewrite rules for API requests.
* [`jobspotter_frontend/vercel.json`](diffhunk://#diff-759b8a19d4c31b2fa6b49fe0d183a7827e084dc2b7aefec23195357a4fc0e878R1-R8): Added a new configuration file with identical rewrite rules, mapping `/api/:match*` to `https://api.jobspotter.eu/:match*`.