### PR TITLE
Jobspotter 143 redis in jobpost

### DIFF
--- a/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/controller/JobPostController.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/controller/JobPostController.java
@@ -623,8 +623,7 @@ public class JobPostController {
 
         log.info("Starting job post");
 
-        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
-        jobPostService.startJobPost(userId, id);
+        jobPostService.startJobPost(accessToken, id);
 
         return ResponseEntity.noContent().build();
     }
@@ -704,8 +703,7 @@ public class JobPostController {
     ) throws Exception {
         log.info("Finishing job post");
 
-        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
-        jobPostService.finishJobPost(userId, id);
+        jobPostService.finishJobPost(accessToken, id);
         return ResponseEntity.noContent().build();
     }
 

--- a/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/controller/JobPostController.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/controller/JobPostController.java
@@ -427,8 +427,7 @@ public class JobPostController {
     ) throws Exception {
         log.info("Applying to job post");
 
-        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
-        jobPostService.applyToJobPost(userId, id, jobPostApplyRequest);
+        jobPostService.applyToJobPost(accessToken, id, jobPostApplyRequest);
 
         return ResponseEntity.noContent().build();
     }

--- a/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/Implementation/JobPostImpl.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/Implementation/JobPostImpl.java
@@ -515,6 +515,7 @@ public class JobPostImpl implements JobPostService {
      * @param jobPostId The ID of the job post to delete
      * @throws Exception If the user is not an admin or job poster, or job post status is not OPEN
      */
+    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Transactional
     @Override
     public void deleteJobPost(String accessToken, Long jobPostId) throws Exception {
@@ -592,7 +593,7 @@ public class JobPostImpl implements JobPostService {
     }
 
 
-
+    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Transactional
     @Override
     public void takeApplicantsAction(UUID userId, Long jobPostId, List<ApplicantActionRequest> applicantsActionRequest) {
@@ -699,7 +700,7 @@ public class JobPostImpl implements JobPostService {
      * @param message The new message to update
      * @throws Exception If the user is not an admin or job poster, job post status is not OPEN, applicant does not exist, or message is empty
      */
-
+    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Override
     public void updateApplicantMessage(String accessToken, Long jobPostId, Long applicantId, String message) throws Exception{
 //        Get the job post from the database
@@ -737,6 +738,7 @@ public class JobPostImpl implements JobPostService {
      * @throws Exception If the user is not an admin or job poster, job post status is not OPEN, or applicant does not exist
      */
     @Transactional
+    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Override
     public void deleteApplicant(String accessToken, Long jobPostId, Long applicantId) throws Exception {
 //        Get the job post from the database
@@ -825,6 +827,7 @@ public class JobPostImpl implements JobPostService {
         log.info("Job post started successfully");
     }
 
+    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Transactional
     @Override
     public void cancelJobPost(String accessToken, Long jobPostId) throws Exception {

--- a/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/Implementation/JobPostImpl.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/Implementation/JobPostImpl.java
@@ -763,11 +763,13 @@ public class JobPostImpl implements JobPostService {
     }
 
     @Transactional
+    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Override
-    public void startJobPost(UUID userId, Long jobPostId) {
+    public void startJobPost(String accessToken, Long jobPostId) throws Exception {
 //        Get the job post from the database
         JobPost jobPost = getJobPostByID(jobPostId);
 
+        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
 //        Check if the user is the job poster
         checkIfUserIsJobPoster(userId, jobPost);
 
@@ -802,7 +804,6 @@ public class JobPostImpl implements JobPostService {
         jobPost.setStatus(JobStatus.IN_PROGRESS);
         jobPostRepository.save(jobPost);
 
-//        TODO: Send notification to all accepted applicants
         notificationService.sendNotification(Notification.builder()
                 .message("Your job post '" + jobPost.getTitle() + "' have started. Good luck!:")
                 .destinationUserId(jobPost.getJobPosterId())
@@ -826,9 +827,8 @@ public class JobPostImpl implements JobPostService {
 
         log.info("Job post started successfully");
     }
-
-    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Transactional
+    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Override
     public void cancelJobPost(String accessToken, Long jobPostId) throws Exception {
 
@@ -867,11 +867,14 @@ public class JobPostImpl implements JobPostService {
     }
 
 
-
+    @Transactional
+    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Override
-    public void finishJobPost(UUID userId, Long jobPostId) {
+    public void finishJobPost(String accessToken, Long jobPostId) throws Exception{
 
         JobPost jobPost = getJobPostByID(jobPostId);
+
+        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
 
         checkIfUserIsJobPoster(userId, jobPost);
 

--- a/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/Implementation/JobPostImpl.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/Implementation/JobPostImpl.java
@@ -22,6 +22,7 @@ import org.jobspotter.jobpost.service.SearchTitleSuggestionService;
 import org.jobspotter.jobpost.utils.GeoUtils;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -515,7 +516,16 @@ public class JobPostImpl implements JobPostService {
      * @param jobPostId The ID of the job post to delete
      * @throws Exception If the user is not an admin or job poster, or job post status is not OPEN
      */
-    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
+    @Caching(evict = {
+            @CacheEvict(
+                    value = "myJobPostCache",
+                    key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId"
+            ),
+            @CacheEvict(
+                    value = "jobPostCache",
+                    key = "#jobPostId"
+            )
+    })
     @Transactional
     @Override
     public void deleteJobPost(String accessToken, Long jobPostId) throws Exception {
@@ -531,8 +541,26 @@ public class JobPostImpl implements JobPostService {
         log.info("Job post deleted successfully");
     }
 
+    /**
+     * Apply to a job post by its ID
+     * Only the job poster and admins can apply to a job post
+     * The job post status must be OPEN if the user is not an admin
+     *
+     * @param accessToken
+     * @param jobPostId   The ID of the job post to apply to
+     * @param jobPostApplyRequest
+     */
+
     @Override
-    public void applyToJobPost(UUID userId, Long jobPostId, JobPostApplyRequest jobPostApplyRequest) {
+    @CacheEvict(
+            value = "myJobPostCache",
+            key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId"
+    )
+    public void applyToJobPost(String accessToken, Long jobPostId, JobPostApplyRequest jobPostApplyRequest) throws Exception {
+
+
+        // Extract userId
+        UUID userId = JWTUtils.getUserIdFromToken(accessToken);
 
         // Find the job post
         JobPost jobPost = getJobPostByID(jobPostId);
@@ -592,9 +620,8 @@ public class JobPostImpl implements JobPostService {
         log.info("User applied to job post successfully");
     }
 
-
-    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Transactional
+    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
     @Override
     public void takeApplicantsAction(UUID userId, Long jobPostId, List<ApplicantActionRequest> applicantsActionRequest) {
 
@@ -763,7 +790,16 @@ public class JobPostImpl implements JobPostService {
     }
 
     @Transactional
-    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
+    @Caching(evict = {
+            @CacheEvict(
+                    value = "myJobPostCache",
+                    key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId"
+            ),
+            @CacheEvict(
+                    value = "jobPostCache",
+                    key = "#jobPostId"
+            )
+    })
     @Override
     public void startJobPost(String accessToken, Long jobPostId) throws Exception {
 //        Get the job post from the database
@@ -828,7 +864,16 @@ public class JobPostImpl implements JobPostService {
         log.info("Job post started successfully");
     }
     @Transactional
-    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
+    @Caching(evict = {
+            @CacheEvict(
+                    value = "myJobPostCache",
+                    key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId"
+            ),
+            @CacheEvict(
+                    value = "jobPostCache",
+                    key = "#jobPostId"
+            )
+    })
     @Override
     public void cancelJobPost(String accessToken, Long jobPostId) throws Exception {
 
@@ -868,7 +913,16 @@ public class JobPostImpl implements JobPostService {
 
 
     @Transactional
-    @CacheEvict(value = "myJobPostCache", key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId")
+    @Caching(evict = {
+            @CacheEvict(
+                    value = "myJobPostCache",
+                    key = "T(org.jobspotter.jobpost.authUtils.JWTUtils).getUserIdFromToken(#accessToken).toString() + ':' + #jobPostId"
+            ),
+            @CacheEvict(
+                    value = "jobPostCache",
+                    key = "#jobPostId"
+            )
+    })
     @Override
     public void finishJobPost(String accessToken, Long jobPostId) throws Exception{
 

--- a/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/JobPostService.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/JobPostService.java
@@ -31,7 +31,7 @@ public interface JobPostService {
 
     void deleteJobPost(String accessToken, Long jobPostId) throws Exception;
 
-    void applyToJobPost(UUID userId, Long jobPostId, JobPostApplyRequest jobPostApplyRequest);
+    void applyToJobPost(String accessToken, Long jobPostId, JobPostApplyRequest request) throws Exception;
 
     void takeApplicantsAction(UUID userId, Long jobPostId, List<ApplicantActionRequest> applicantsActionRequest);
 

--- a/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/JobPostService.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/JobPostService.java
@@ -39,11 +39,11 @@ public interface JobPostService {
 
     void deleteApplicant(String accessToken, Long jobPostId, Long applicantId) throws Exception;
 
-    void startJobPost(UUID userId, Long jobPostId) ;
+    void startJobPost(String accessToken, Long jobPostId) throws Exception ;
 
     void cancelJobPost(String accessToken, Long jobPostId) throws Exception;
 
-    void finishJobPost(UUID userId, Long jobPostId);
+    void finishJobPost(String accessToken, Long jobPostId) throws Exception;
 
     Applicant getApplicantById(String accessToken, Long applicantId) throws Exception;
 

--- a/jobspotter_backend/services/job-post/src/test/java/org/jobspotter/jobpost/UnitTests/UnitTests/JobPostServiceImplTests.java
+++ b/jobspotter_backend/services/job-post/src/test/java/org/jobspotter/jobpost/UnitTests/UnitTests/JobPostServiceImplTests.java
@@ -1252,8 +1252,9 @@ public class JobPostServiceImplTests {
      * </p>
      */
     @Test
-    void startJobPost_Success() {
+    void startJobPost_Success() throws Exception {
         // Arrange
+        String accessToken = "mocked-access-token";
         UUID userId = UUID.randomUUID();
         Long jobPostId = 1L;
 
@@ -1279,18 +1280,22 @@ public class JobPostServiceImplTests {
                 .build();
 
         when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+        when(jwtUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
 
         // Act
-        jobPostImpl.startJobPost(userId, jobPostId);
+        jobPostImpl.startJobPost(accessToken, jobPostId);
 
         // Assert
         assertEquals(JobStatus.IN_PROGRESS, jobPost.getStatus(), "Job post should be IN_PROGRESS");
+
         assertTrue(jobPost.getApplicants().stream()
-                .noneMatch(applicant -> applicant.getStatus() == ApplicantStatus.PENDING), "All PENDING applicants must be REJECTED");
+                        .noneMatch(applicant -> applicant.getStatus() == ApplicantStatus.PENDING),
+                "All PENDING applicants must be REJECTED");
 
         verify(applicantRepository).saveAll(applicants);
         verify(jobPostRepository).save(jobPost);
     }
+
 
     //no accepted applicants
     /**
@@ -1301,8 +1306,9 @@ public class JobPostServiceImplTests {
      * </p>
      */
     @Test
-    void startJobPost_NoAcceptedApplicants_ThrowsInvalidRequestException() {
+    void startJobPost_NoAcceptedApplicants_ThrowsInvalidRequestException() throws Exception {
         // Arrange
+        String accessToken = "mocked-access-token";
         UUID userId = UUID.randomUUID();
         Long jobPostId = 1L;
 
@@ -1322,14 +1328,17 @@ public class JobPostServiceImplTests {
                 .build();
 
         when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
+        when(jwtUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
 
         // Act & Assert
         InvalidRequestException exception = assertThrows(InvalidRequestException.class,
-                () -> jobPostImpl.startJobPost(userId, jobPostId));
+                () -> jobPostImpl.startJobPost(accessToken, jobPostId));
+
         assertTrue(exception.getMessage().contains("At least 1 applicant must be accepted"));
 
         verify(jobPostRepository).findById(jobPostId);
     }
+
 //Canncel Job Post
     //===================================================================================================================
     /**

--- a/jobspotter_backend/services/job-post/src/test/java/org/jobspotter/jobpost/UnitTests/UnitTests/JobPostServiceImplTests.java
+++ b/jobspotter_backend/services/job-post/src/test/java/org/jobspotter/jobpost/UnitTests/UnitTests/JobPostServiceImplTests.java
@@ -273,7 +273,7 @@ public class JobPostServiceImplTests {
             // And return false for admin role.
             when(jwtUtils.hasAdminRole(accessToken)).thenReturn(false);
 
-            // Act & Assert: Expect UnauthorizedException to be thrown.
+            // Act/ Assert: Expect UnauthorizedException to be thrown.
             Exception exception = assertThrows(UnauthorizedException.class,
                     () -> jobPostImpl.getMyJobPostDetails(accessToken, 1L));
             assertTrue(exception.getMessage().contains("You are not authorized"));
@@ -629,7 +629,7 @@ public class JobPostServiceImplTests {
         when(userServiceClient.getAddressById(accessToken, request.getAddressId()))
                 .thenThrow(notFoundException);
 
-        // Act & Assert
+        // Act/ Assert
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
                 () -> jobPostImpl.createJobPost(accessToken, request));
 
@@ -709,7 +709,7 @@ public class JobPostServiceImplTests {
             when(jwtUtils.hasAdminRole(accessToken)).thenReturn(false);
             when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
 
-            // Act & Assert
+            // Act/ Assert
             assertThrows(ForbiddenException.class,
                     () -> jobPostImpl.updateJobPost(accessToken, jobPostId, patchRequest));
         }
@@ -802,30 +802,36 @@ public class JobPostServiceImplTests {
      * </p>
      */
     @Test
-    void applyToJobPost_Success() {
+    void applyToJobPost_Success() throws Exception {
         // Arrange
-        JobPost jobPost = getDummyJobPost(); // Status OPEN
+        String accessToken = "mocked-access-token";
         UUID userId = UUID.randomUUID();
+        JobPost jobPost = getDummyJobPost(); // Status OPEN
         JobPostApplyRequest applyRequest = new JobPostApplyRequest("Excited to apply!");
 
         when(jobPostRepository.findById(1L)).thenReturn(Optional.of(jobPost));
 
-        // Act
-        jobPostImpl.applyToJobPost(userId, 1L, applyRequest);
+        try (MockedStatic<JWTUtils> jwtUtilsMocked = mockStatic(JWTUtils.class)) {
+            jwtUtilsMocked.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
 
-        // Assert
-        assertEquals(1, jobPost.getApplicants().size());
+            // Act
+            jobPostImpl.applyToJobPost(accessToken, 1L, applyRequest);
 
-        Applicant savedApplicant = jobPost.getApplicants().iterator().next();
-        assertEquals(userId, savedApplicant.getUserId());
-        assertEquals("Excited to apply!", savedApplicant.getMessage());
-        assertEquals(ApplicantStatus.PENDING, savedApplicant.getStatus());
+            // Assert
+            assertEquals(1, jobPost.getApplicants().size());
 
-        verify(applicantRepository).save(any(Applicant.class));
-        verify(jobPostRepository).save(jobPost);
-        verify(notificationService, times(2)).sendNotification(any(), eq(KafkaTopic.APPLICANT_APPLIED));
+            Applicant savedApplicant = jobPost.getApplicants().iterator().next();
+            assertEquals(userId, savedApplicant.getUserId());
+            assertEquals("Excited to apply!", savedApplicant.getMessage());
+            assertEquals(ApplicantStatus.PENDING, savedApplicant.getStatus());
 
+            verify(applicantRepository).save(any(Applicant.class));
+            verify(jobPostRepository).save(jobPost);
+            verify(notificationService, times(2)).sendNotification(any(), eq(KafkaTopic.APPLICANT_APPLIED));
+        }
     }
+
+
 
     /**
      * Testing for a successful application to a job post when the job post is not open.
@@ -837,21 +843,28 @@ public class JobPostServiceImplTests {
     @Test
     void applyToJobPost_NotOpenStatus_ShouldThrowForbiddenException() {
         // Arrange
+        String accessToken = "mocked-access-token";
         UUID userId = UUID.randomUUID();
         JobPost jobPost = getDummyJobPost();
         jobPost.setStatus(JobStatus.COMPLETED); // Not OPEN
 
         when(jobPostRepository.findById(1L)).thenReturn(Optional.of(jobPost));
 
-        // Act & Assert
-        ForbiddenException exception = assertThrows(ForbiddenException.class,
-                () -> jobPostImpl.applyToJobPost(userId, 1L, new JobPostApplyRequest("Applying to closed job")));
+        try (MockedStatic<JWTUtils> jwtUtilsMocked = mockStatic(JWTUtils.class)) {
+            jwtUtilsMocked.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
 
-        assertTrue(exception.getMessage().contains("JobStatus does not allow for this action"));
+            // Act & Assert
+            ForbiddenException exception = assertThrows(ForbiddenException.class,
+                    () -> jobPostImpl.applyToJobPost(accessToken, 1L, new JobPostApplyRequest("Applying to closed job")));
 
-        verify(applicantRepository, never()).save(any());
-        verify(jobPostRepository, never()).save(any());
+            assertTrue(exception.getMessage().contains("JobStatus does not allow for this action"));
+
+            verify(applicantRepository, never()).save(any());
+            verify(jobPostRepository, never()).save(any());
+        }
     }
+
+
 
     /**
      * Testing for a successful application to a job post when the user is already an applicant.
@@ -861,8 +874,9 @@ public class JobPostServiceImplTests {
      * </p>
      */
     @Test
-    void applyToJobPost_AlreadyApplied_ShouldThrowForbiddenException() {
+    void applyToJobPost_AlreadyApplied_ShouldThrowForbiddenException() throws Exception {
         // Arrange
+        String accessToken = "mocked-access-token";
         UUID userId = UUID.randomUUID();
         JobPost jobPost = getDummyJobPost();
         jobPost.getApplicants().add(Applicant.builder()
@@ -872,15 +886,21 @@ public class JobPostServiceImplTests {
 
         when(jobPostRepository.findById(1L)).thenReturn(Optional.of(jobPost));
 
-        // Act & Assert
-        ForbiddenException exception = assertThrows(ForbiddenException.class,
-                () -> jobPostImpl.applyToJobPost(userId, 1L, new JobPostApplyRequest("Applying again")));
+        try (MockedStatic<JWTUtils> jwtUtilsMocked = mockStatic(JWTUtils.class)) {
+            jwtUtilsMocked.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
 
-        assertTrue(exception.getMessage().contains("already applied"));
+            // Act & Assert
+            ForbiddenException exception = assertThrows(ForbiddenException.class,
+                    () -> jobPostImpl.applyToJobPost(accessToken, 1L, new JobPostApplyRequest("Applying again")));
 
-        verify(applicantRepository, never()).save(any());
-        verify(jobPostRepository, never()).save(any());
+            assertTrue(exception.getMessage().contains("already applied"));
+
+            verify(applicantRepository, never()).save(any());
+            verify(jobPostRepository, never()).save(any());
+        }
     }
+
+
 
     // Test Methods for takeActionOnApplication
     //==================================================================================================================
@@ -1197,7 +1217,7 @@ public class JobPostServiceImplTests {
         when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
         when(jwtUtils.hasAdminRole(accessToken)).thenReturn(true);
 
-        // Act & Assert
+        // Act/ Assert
         assertThrows(ResourceNotFoundException.class, () ->
                 jobPostImpl.deleteApplicant(accessToken, jobPostId, invalidApplicantId));
 
@@ -1235,7 +1255,7 @@ public class JobPostServiceImplTests {
         when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
         when(jwtUtils.hasAdminRole(accessToken)).thenReturn(true);
 
-        // Act & Assert
+        // Act/ Assert
         assertThrows(ForbiddenException.class, () ->
                 jobPostImpl.deleteApplicant(accessToken, jobPostId, applicantId));
 
@@ -1280,20 +1300,23 @@ public class JobPostServiceImplTests {
                 .build();
 
         when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
-        when(jwtUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
 
-        // Act
-        jobPostImpl.startJobPost(accessToken, jobPostId);
+        try (MockedStatic<JWTUtils> jwtUtilsMocked = mockStatic(JWTUtils.class)) {
+            jwtUtilsMocked.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
 
-        // Assert
-        assertEquals(JobStatus.IN_PROGRESS, jobPost.getStatus(), "Job post should be IN_PROGRESS");
+            // Act
+            jobPostImpl.startJobPost(accessToken, jobPostId);
 
-        assertTrue(jobPost.getApplicants().stream()
-                        .noneMatch(applicant -> applicant.getStatus() == ApplicantStatus.PENDING),
-                "All PENDING applicants must be REJECTED");
+            // Assert
+            assertEquals(JobStatus.IN_PROGRESS, jobPost.getStatus(), "Job post should be IN_PROGRESS");
 
-        verify(applicantRepository).saveAll(applicants);
-        verify(jobPostRepository).save(jobPost);
+            assertTrue(jobPost.getApplicants().stream()
+                            .noneMatch(applicant -> applicant.getStatus() == ApplicantStatus.PENDING),
+                    "All PENDING applicants must be REJECTED");
+
+            verify(applicantRepository).saveAll(applicants);
+            verify(jobPostRepository).save(jobPost);
+        }
     }
 
 
@@ -1328,16 +1351,19 @@ public class JobPostServiceImplTests {
                 .build();
 
         when(jobPostRepository.findById(jobPostId)).thenReturn(Optional.of(jobPost));
-        when(jwtUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
 
-        // Act & Assert
-        InvalidRequestException exception = assertThrows(InvalidRequestException.class,
-                () -> jobPostImpl.startJobPost(accessToken, jobPostId));
+        try (MockedStatic<JWTUtils> jwtUtilsMocked = mockStatic(JWTUtils.class)) {
+            jwtUtilsMocked.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(userId);
 
-        assertTrue(exception.getMessage().contains("At least 1 applicant must be accepted"));
+            // Act & Assert
+            InvalidRequestException exception = assertThrows(InvalidRequestException.class,
+                    () -> jobPostImpl.startJobPost(accessToken, jobPostId));
 
-        verify(jobPostRepository).findById(jobPostId);
+            assertTrue(exception.getMessage().contains("At least 1 applicant must be accepted"));
+            verify(jobPostRepository).findById(jobPostId);
+        }
     }
+
 
 //Canncel Job Post
     //===================================================================================================================
@@ -1412,7 +1438,7 @@ public class JobPostServiceImplTests {
             jwtUtilsMockedStatic.when(() -> JWTUtils.getUserIdFromToken(accessToken)).thenReturn(jobPosterId);
             when(jwtUtils.hasAdminRole(accessToken)).thenReturn(false);
 
-            // Act & Assert
+            // Act/ Assert
             ForbiddenException exception = assertThrows(ForbiddenException.class,
                     () -> jobPostImpl.cancelJobPost(accessToken, jobPostId));
             assertTrue(exception.getMessage().contains("JobStatus does not allow"));


### PR DESCRIPTION

### Refactoring of `JobPostService` methods:
* Replaced `UUID userId` with `String accessToken` in the method signatures of `applyToJobPost`, `startJobPost`, and `finishJobPost` in `JobPostService` and its implementation. The `userId` is now extracted directly from the `accessToken` within the methods. [[1]](diffhunk://#diff-6b651c3212abd9ba5ab3ff994b3ac995d2fb13540f6d2b3a8ba19a1de541a539L430-R430) [[2]](diffhunk://#diff-6b651c3212abd9ba5ab3ff994b3ac995d2fb13540f6d2b3a8ba19a1de541a539L626-R625) [[3]](diffhunk://#diff-6b651c3212abd9ba5ab3ff994b3ac995d2fb13540f6d2b3a8ba19a1de541a539L707-R705) [[4]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R544-R563) [[5]](diffhunk://#diff-378797a5d461fef36aa051f00d13ce8b3140bd0a72a01b9e9d8e31120caf4626L34-R46)

### Caching improvements:
* Added `@CacheEvict` and `@Caching` annotations to methods like `deleteJobPost`, `applyToJobPost`, `startJobPost`, `cancelJobPost`, and `finishJobPost` to evict relevant cache entries when these methods are executed. This ensures cache consistency. [[1]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R519-R528) [[2]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R544-R563) [[3]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R793-R808) [[4]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942L827-R876) [[5]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942L867-R932)

### Unit test updates:
* Updated unit tests to use `accessToken` instead of `userId` and mocked `JWTUtils.getUserIdFromToken` to extract `userId` from `accessToken`. Adjusted test cases to verify the new behavior. [[1]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fL805-R818) [[2]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fL827-R834) [[3]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fR846-R867) [[4]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fL864-R879) [[5]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fR889-R903)
* Fixed minor typos in comments (e.g., "Act & Assert" was changed to "Act/ Assert"). [[1]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fL276-R276) [[2]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fL632-R632) [[3]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fL712-R712) [[4]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fL1200-R1220) [[5]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fL1238-R1258)