### PR TITLE
Jobspotter 143 redis in jobpost

### DIFF
--- a/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/Implementation/JobPostImpl.java
+++ b/jobspotter_backend/services/job-post/src/main/java/org/jobspotter/jobpost/service/Implementation/JobPostImpl.java
@@ -57,8 +57,7 @@ public class JobPostImpl implements JobPostService {
 
     private static final String TOP_JOB_POSTS_KEY = "top10:jobposts";
 
-    @Autowired
-    private CacheManager cacheManager;
+    private final CacheManager cacheManager;
     //----------------------------------------------------------------------------------------------------------------
     //                                     Job Post Get View Queries implementation
     //----------------------------------------------------------------------------------------------------------------

--- a/jobspotter_backend/services/job-post/src/test/java/org/jobspotter/jobpost/UnitTests/UnitTests/JobPostServiceImplTests.java
+++ b/jobspotter_backend/services/job-post/src/test/java/org/jobspotter/jobpost/UnitTests/UnitTests/JobPostServiceImplTests.java
@@ -17,6 +17,7 @@ import org.jobspotter.jobpost.repository.JobPostSpecificationRepository;
 import org.jobspotter.jobpost.service.Implementation.JobPostImpl;
 import org.jobspotter.jobpost.service.NotificationService;
 import org.jobspotter.jobpost.service.SearchTitleSuggestionService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,6 +26,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -55,6 +58,12 @@ import static org.mockito.Mockito.mockStatic;
 public class JobPostServiceImplTests {
 
     @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private Cache cache;
+
+    @Mock
     private RedisTemplate<String, Object> redisTemplate;
 
     @Mock
@@ -81,7 +90,10 @@ public class JobPostServiceImplTests {
     @InjectMocks
     private JobPostImpl jobPostImpl;
 
-
+    @BeforeEach
+    void setup() {
+        when(cacheManager.getCache("jobPostCache")).thenReturn(cache);
+    }
     //==================================================================================================================
     //                                     TESTS FOR MAIN JOB POST SERVICE METHODS
     //==================================================================================================================


### PR DESCRIPTION

### Manual cache eviction implementation:

* [`JobPostImpl.java`](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R23-R24): Added a `CacheManager` dependency to the class and implemented manual cache eviction for the `startJobPost`, `cancelJobPost`, and `finishJobPost` methods. This ensures that the `jobPostCache` is updated whenever a job post's status changes. [[1]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R23-R24) [[2]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R60) [[3]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R846-R848) [[4]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R904-R906) [[5]](diffhunk://#diff-4dfdb1c52d5bb2a3178d95069e7cf609c96aacecfc68d1acf8f3f1222e624942R950-R951)

### Unit test updates:

* [`JobPostServiceImplTests.java`](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fR20): Added mock objects for `CacheManager` and `Cache`. Introduced a `setup` method annotated with `@BeforeEach` to configure the behavior of the mocked `CacheManager`. These changes allow testing of cache eviction logic in the `JobPostImpl` class. [[1]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fR20) [[2]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fR29-R30) [[3]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fR60-R65) [[4]](diffhunk://#diff-3fc19441bf231467bbdb71eeb555857b612ad78696c6325ca54ed3c3ec4a942fL84-R96)