### PR TITLE
feat: add deployment scripts for Spring Boot and support services

### DIFF
--- a/deployment/home_server/DatabaseSetup.sh
+++ b/deployment/home_server/DatabaseSetup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# PostgreSQL details
+POSTGRES_CONTAINER_NAME="postgres"   # your postgres container name
+POSTGRES_USER="postgres"             # your postgres user
+POSTGRES_PASSWORD="root"             # your postgres password
+
+# MongoDB details
+MONGO_CONTAINER_NAME="mongodb"
+MONGO_USERNAME="admin"
+MONGO_PASSWORD="admin"
+
+# -----------------------------------------------
+echo "Setting up PostgreSQL databases..."
+
+# Run inside Postgres container
+docker exec -e PGPASSWORD=$POSTGRES_PASSWORD $POSTGRES_CONTAINER_NAME psql -U $POSTGRES_USER -d postgres -c 'CREATE DATABASE "job-post";'
+docker exec -e PGPASSWORD=$POSTGRES_PASSWORD $POSTGRES_CONTAINER_NAME psql -U $POSTGRES_USER -d postgres -c 'CREATE DATABASE "review";'
+docker exec -e PGPASSWORD=$POSTGRES_PASSWORD $POSTGRES_CONTAINER_NAME psql -U $POSTGRES_USER -d postgres -c 'CREATE DATABASE "user";'
+
+echo "PostgreSQL databases created!"
+
+# -----------------------------------------------
+echo "Setting up MongoDB collections..."
+
+docker exec $MONGO_CONTAINER_NAME mongosh --username $MONGO_USERNAME --password $MONGO_PASSWORD --authenticationDatabase admin --eval "
+use notification;
+db.createCollection('notifications');
+"
+
+echo "MongoDB databases and collections created!"

--- a/deployment/home_server/JobSpotterServerStartup.sh
+++ b/deployment/home_server/JobSpotterServerStartup.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+echo"   ___       _       ___________     _   _              _   _  __    _____                          "
+echo"  |_  |     | |     /  ___| ___ \   | | | |            | | | |/  |  /  ___|                         "
+echo"    | | ___ | |__   \ `--.| |_/ /__ | |_| |_ ___ _ __  | | | |`| |  \ `--.  ___ _ ____   _____ _ __ "
+echo"    | |/ _ \| '_ \   `--. \  __/ _ \| __| __/ _ \ '__| | | | | | |   `--. \/ _ \ '__\ \ / / _ \ '__|"
+echo"/\__/ / (_) | |_) | /\__/ / | | (_) | |_| ||  __/ |    \ \_/ /_| |_ /\__/ /  __/ |   \ V /  __/ |   "
+echo"\____/ \___/|_.__/  \____/\_|  \___/ \__|\__\___|_|     \___/ \___/ \____/ \___|_|    \_/ \___|_|   "
+echo"                                                                                                    "
+                                                                                                    
+
+echo ""
+echo "Welcome to JobSpotter Server Manager!"
+echo "------------------------------------"
+
+# Functions
+start_support_services() {
+  echo "Starting support services one by one with 10s delay..."
+  services=(
+    postgresql
+    mongodb
+    zookeeper
+    keycloak-db
+    keycloak
+    redis
+    zipkin
+    prometheus
+    grafana
+    kafka
+  )
+  for service in "${services[@]}"; do
+    echo "Starting service: $service"
+    docker compose up -d "$service"
+    echo "Waiting 10 seconds before starting next service..."
+    sleep 10
+  done
+  echo "Support services started."
+}
+
+start_spring_services() {
+  echo "Starting Spring Boot services one by one with 10s delay..."
+  services=(
+    config-server
+    discovery
+    gateway
+    job-post
+    notification
+    report
+    review
+    user
+  )
+  for service in "${services[@]}"; do
+    echo "Starting service: $service"
+    docker compose up -d "$service"
+    echo "Waiting 10 seconds before starting next service..."
+    sleep 10
+  done
+  echo "Spring Boot services started."
+}
+
+start_full_stack() {
+  echo "Starting full JobSpotter stack..."
+  start_support_services
+  echo "Waiting extra 20 seconds before starting Spring services..."
+  sleep 20
+  start_spring_services
+  echo "JobSpotter Server fully started."
+}
+
+update_docker_images() {
+  echo "Starting to pull latest Docker images..."
+  echo "------------------------------------"
+  images=(
+    postgres
+    mongo
+    redis/redis-stack
+    confluentinc/cp-kafka
+    confluentinc/cp-zookeeper
+    quay.io/keycloak/keycloak
+    grafana/grafana
+    prom/prometheus
+    openzipkin/zipkin
+    jobspotter/config-server
+    jobspotter/discovery
+    jobspotter/gateway
+    jobspotter/job-post
+    jobspotter/notification
+    jobspotter/report
+    jobspotter/review
+    jobspotter/user
+  )
+  for image in "${images[@]}"; do
+    echo "Pulling latest image: $image"
+    docker pull "$image:latest"
+    echo "------------------------------------"
+    sleep 2
+  done
+  echo "All images pulled successfully."
+  echo "------------------------------------"
+}
+remove_old_images() {
+  echo "Removing unused and dangling Docker images..."
+  docker image prune -af
+  echo "Old images removed."
+  echo "------------------------------------"
+}
+
+# Menu Loop
+while true; do
+  echo ""
+  echo "Menu:"
+  echo "------------------------------------"
+  echo "1) Start Support Services"
+  echo "2) Start Spring Boot Services"
+  echo "3) Start Everything (Full Stack)"
+  echo "4) Update Docker Images"
+  echo "5) Remove Old Docker Images"
+  echo "6) Exit"
+  echo "------------------------------------"
+  read -p "Please enter your choice [1-6]: " choice
+  echo ""
+
+  case $choice in
+    1)
+      start_support_services
+      ;;
+    2)
+      start_spring_services
+      ;;
+    3)
+      start_full_stack
+      ;;
+    4)
+      update_docker_images
+      ;;
+    5)
+      remove_old_images
+      ;;
+    6)
+      echo "Exiting JobSpotter Manager."
+      exit 0
+      ;;
+    *)
+      echo "Invalid option. Please choose 1-6."
+      ;;
+  esac
+
+  echo "------------------------------------"
+done

--- a/deployment/home_server/KafkaClean.sh
+++ b/deployment/home_server/KafkaClean.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+docker compose down kafka zookeeper
+echo " Cleaning up old Kafka ..."
+docker rm -f kafka 
+
+echo "Cleaning up old Kafka and ..."
+docker volume rm $(docker volume ls -qf "name=kafka") || true
+
+echo "Cleaning up old Kafka and Zookeeper networks..."
+docker network prune -f
+
+echo " Starting fresh zookeeper..."
+docker compose up -d zookeeper
+
+sleep 5
+
+echo "Starting fresh kafka..."
+docker compose up -d kafka
+  

--- a/deployment/home_server/SpringServices.sh
+++ b/deployment/home_server/SpringServices.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+services=(
+  config-server
+  discovery
+  gateway
+  job-post
+  notification
+  report
+  review
+  user
+)
+
+for service in "${services[@]}"; do
+  echo "Starting service: $service"
+  docker compose up -d "$service"
+  echo "Waiting 10 seconds before starting next service..."
+  sleep 10
+done
+
+echo "All Spring Boot services started"

--- a/deployment/home_server/SupportServices.sh
+++ b/deployment/home_server/SupportServices.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "Starting support services one by one with 10s delay..."
+
+services=(
+  postgresql
+  mongodb
+  zookeeper
+  keycloak-db
+  keycloak
+  redis
+  zipkin
+  prometheus
+  grafana
+  kafka
+)
+
+for service in "${services[@]}"; do
+  echo "Starting service: $service"
+  docker compose up -d "$service"
+  echo "Waiting 10 seconds before starting next service..."
+  sleep 10
+done
+
+echo "All support services started!"

--- a/deployment/home_server/docker-compose.yml
+++ b/deployment/home_server/docker-compose.yml
@@ -1,0 +1,294 @@
+services:
+
+  #----------------------PostgreSQL------------------------
+  postgresql:
+    container_name: postgres
+    image: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: root
+      PGDATA: /data/postgres
+    volumes:
+      - postgres:/data/postgres
+    ports:
+      - "1234:5432"
+    networks:
+      - jobspotterserver_jobSpotter-net
+    restart: unless-stopped
+
+  #----------------------MongoDB------------------------
+  mongodb:
+    image: mongo
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb:/data
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=admin
+    networks:
+      - jobspotterserver_jobSpotter-net  # Include MongoDB in the network
+
+  #----------------------Kafka and zookeper------------------------
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    volumes:
+      - zookeeper-data:/data
+      - zookeeper-datalog:/datalog
+    ports:
+      - "22181:2181"
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT, PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+
+  #----------------------Keycloak------------------------
+  keycloak-db:
+    image: postgres:15
+    container_name: keycloak-db
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: password
+    volumes:
+      - keycloak_db:/var/lib/postgresql/data
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0.0
+    container_name: keycloak
+    environment:
+      KC_DB: postgres
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: password
+      KC_DB_URL: jdbc:postgresql://keycloak-db/keycloak
+      KC_HOSTNAME: keycloak
+      KC_HTTP_ENABLED: true
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_LOG_LEVEL: info
+    command: start-dev --import-realm
+    ports:
+      - "9090:8080"
+    depends_on:
+      - keycloak-db
+    volumes:
+      - keycloak:/opt/keycloak/data
+      - ./keycloak/realm-import.json:/opt/keycloak/data/import/realm-import.json:ro
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+
+
+  #        ----------------------Redis-------------------------
+
+  redis:
+    image: redis/redis-stack:latest  #  Use Redis Stack (Includes RediSearch)
+    container_name: redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+      - "8001:8001"  # RedisInsight UI
+    volumes:
+      - redis:/data
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+  #        --------------------------------------------Tools (Monitoring, Tracing)---------------------------------------------
+
+  #----------------------Zipkin------------------------
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: zipkin
+    ports:
+      - "9411:9411"
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+
+  #----------------------Prometheus------------------------
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus_1
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - jobspotterserver_jobSpotter-net
+    restart: unless-stopped
+
+
+  #----------------------Grafana------------------------
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    depends_on:
+      - prometheus
+    links:
+      - prometheus:prometheus # Link to Prometheus
+    networks:
+      - jobspotterserver_jobSpotter-net
+    restart: unless-stopped
+    volumes:
+      - ./grafana:/var/lib/grafana  # Persist Grafana data
+
+
+
+
+
+
+  #      ---------------------------------------JOBSPOTTER SERVICES------------------------------------------------
+
+  #----------------------Config Server------------------------
+  config-server:
+    container_name: config-server
+    image: jobspotter/config-server:latest
+    ports:
+      - "8888:8888"
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+  #----------------------Discovery Server (Eureka)------------------------
+  discovery:
+    container_name: discovery-service
+    image: jobspotter/discovery:latest
+    ports:
+      - "8761:8761"
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+  #----------------------Gateway------------------------
+  gateway:
+    container_name: gateway
+    image: jobspotter/gateway:latest
+    ports:
+      - "8100:8100"
+    environment:
+      - KEYCLOAK_ADMIN_CLIENT_ID=${KEYCLOAK_ADMIN_CLIENT_ID}
+      - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD}
+      - KEYSTORE_LOCATION=${KEYSTORE_LOCATION}
+      - CERTIFICATE_LOCATION=${CERTIFICATE_LOCATION}
+      - SSL_ON=true
+    volumes:
+      - ./certs:/ssl
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+  #----------------------Job Post Service------------------------
+  job-post:
+    container_name: job-post
+    image: jobspotter/job-post:latest
+    ports:
+      - "8081:8081"
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+
+
+  #----------------------Notification Service------------------------
+  notification:
+    container_name: notification
+    image: jobspotter/notification:latest
+    ports:
+      - "8083:8083"
+    networks:
+      - jobspotterserver_jobSpotter-net
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+
+  #----------------------Report Service------------------------
+  report:
+    container_name: report
+    image:  jobspotter/report:latest
+    ports:
+      - "8084:8084"
+    networks:
+      - jobspotterserver_jobSpotter-net
+    environment:
+      - KEYCLOAK_HOST_URL=${KEYCLOAK_HOST_URL}
+
+  #----------------------Review Service------------------------
+  review:
+    container_name: review
+    image:  jobspotter/review:latest
+    ports:
+      - "8082:8082"
+    networks:
+      - jobspotterserver_jobSpotter-net
+
+  #----------------------User Service------------------------
+  user:
+    container_name: user
+    image:  jobspotter/user:latest
+    ports:
+      - "8080:8080"
+    networks:
+      - jobspotterserver_jobSpotter-net
+    environment:
+      - AWS_S3_BUCKET=${AWS_S3_BUCKET}
+      - AWS_S3_ACCESS_KEY_ID=${AWS_S3_ACCESS_KEY_ID}
+      - AWS_S3_SECRET_ACCESS_KEY=${AWS_S3_SECRET_ACCESS_KEY}
+      - AWS_S3_REGION=${AWS_S3_REGION}
+      - KEYCLOAK_ADMIN_CLIENT_ID=${KEYCLOAK_ADMIN_CLIENT_ID}
+      - KEYCLOAK_ADMIN_USERNAME=${KEYCLOAK_ADMIN_USERNAME}
+      - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD}
+      - GOOGLE_GEOCODING_API_KEY=${GOOGLE_GEOCODING_API_KEY}
+      - KEYCLOAK_HOST_URL=${KEYCLOAK_HOST_URL}
+
+
+
+#        ----------------------Network------------------------
+
+networks:
+  jobspotterserver_jobSpotter-net:
+    driver: bridge
+    external: true
+
+volumes:
+  postgres:
+  mongodb:
+  keycloak:
+  keycloak_db:
+  redis: {}
+  zookeeper-data: {}
+  zookeeper-datalog: {}
+  kafka-data: {}
+  grafana: {}

--- a/deployment/home_server/prometheus/prometheus.yml
+++ b/deployment/home_server/prometheus/prometheus.yml
@@ -1,0 +1,60 @@
+global:
+  scrape_interval: 10s # Poll interval for metrics
+  evaluation_interval: 10s # Evaluate rules every 10 seconds
+
+scrape_configs:
+  - job_name: 'config_server'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['config-server:8888']
+        labels:
+          application: 'Config Server Application'
+
+  - job_name: 'discovery_service'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['discovery-service:8761']
+        labels:
+          application: 'Discovery Service Application'
+
+  - job_name: 'gateway_service'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['gateway-service:8100']
+        labels:
+          application: 'Gateway Application'
+
+  - job_name: 'user_service'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['user-service:8080']
+        labels:
+          application: 'User Service Application'
+
+  - job_name: 'job_post_service'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['job-post-service:8081']
+        labels:
+          application: 'JobPost Service Application'
+
+  - job_name: 'review_service'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['review-service:8082']
+        labels:
+          application: 'Reviews-Ratings Service Application'
+
+  - job_name: 'notification_service'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['notification-service:8083']
+        labels:
+          application: 'Notification Service Application'
+
+  - job_name: 'report_service'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['report-service:8084']
+        labels:
+          application: 'Reviews-Ratings Service Application'


### PR DESCRIPTION
This pull request introduces a comprehensive deployment setup for the JobSpotter server, including scripts for managing services, Docker Compose configurations, and monitoring support. The changes aim to streamline the deployment and management of the server stack, which includes support services, Spring Boot microservices, and monitoring tools.

### Deployment Scripts
* Added `DatabaseSetup.sh` to automate the creation of PostgreSQL databases and MongoDB collections for the application.
* Introduced `JobSpotterServerStartup.sh` as a central script to manage the startup of support services, Spring Boot services, and the entire stack, with options to update or clean Docker images.
* Added `KafkaClean.sh` to reset Kafka and Zookeeper by removing old containers, volumes, and networks, and restarting fresh instances.
* Created `SpringServices.sh` and `SupportServices.sh` to start Spring Boot and support services respectively, with a delay between service startups for stability. [[1]](diffhunk://#diff-e8432eaf137cf32446d09616c00caa713cfc68359cf705f36d4bf48dc80927bfR1-R21) [[2]](diffhunk://#diff-305594dd92735b3b3bcfc9cfcdc36cc115342e4ae03618bf6a1987311092f2d1R1-R25)

### Docker Compose Configuration
* Added a `docker-compose.yml` file defining services for PostgreSQL, MongoDB, Kafka, Zookeeper, Redis, Keycloak, monitoring tools (Prometheus, Grafana, Zipkin), and the JobSpotter microservices. Includes environment variables, volumes, and network configurations.

### Monitoring and Metrics
* Configured Prometheus with a `prometheus.yml` file to scrape metrics from all JobSpotter microservices and support services, enabling detailed monitoring.